### PR TITLE
ILRepack doesn't work with default parameter values... well.. now it does...

### DIFF
--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -883,6 +883,8 @@ namespace ILRepacking
         private void CloneTo(ParameterDefinition param, MethodDefinition context, Collection<ParameterDefinition> col)
         {
             ParameterDefinition pd = new ParameterDefinition(param.Name, param.Attributes, Import(param.ParameterType, context));
+            if (param.HasConstant)
+              pd.Constant = param.Constant;
             if (param.HasMarshalInfo)
                 pd.MarshalInfo = param.MarshalInfo;
             if (param.HasCustomAttributes)


### PR DESCRIPTION
Currently when ILRepack is run against an assembly with default params, the default param flags are copied, but the default constant is NOT...

so when a method like:

``` c#
void Foo(int x = 3)
{
  return x;
}
```

was processed, the resulting assembly would crash on mono and not compile on ms .NET since the constant was missing from the method definition...

this 2 line change in the MethodDefinition clone method fixes this...
