### PR TITLE
ILRepack doesn't detect mdb files properly, hence those are not merged/created by cecil

### DIFF
--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -362,7 +362,7 @@ namespace ILRepacking
                 {
                     ReaderParameters rp = new ReaderParameters(ReadingMode.Immediate);
                     // read PDB/MDB?
-                    if (DebugInfo && (File.Exists(Path.ChangeExtension(assembly, "pdb")) || File.Exists(Path.ChangeExtension(assembly, "mdb"))))
+                    if (DebugInfo && (File.Exists(Path.ChangeExtension(assembly, "pdb")) || File.Exists(assembly + ".mdb")))
                     {
                         rp.ReadSymbols = true;
                     }


### PR DESCRIPTION
mono .mdb files are named "xxx.{dll,exe}.mdb" rather than xxx.pdb as they are in windows.

This small patch fixes the detection predicate to actually work on mono.
