### PR TITLE
Duplicate Reference check includes version

### DIFF
--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -947,7 +947,7 @@ namespace ILRepacking
             foreach (var z in MergedAssemblies.SelectMany(x => x.Modules).SelectMany(x => x.AssemblyReferences))
             {
                 string name = z.Name;
-                if (!MergedAssemblies.Any(y => y.Name.Name == name) && TargetAssemblyDefinition.Name.Name != name && !TargetAssemblyMainModule.AssemblyReferences.Any(y => y.Name == name))
+                if (!MergedAssemblies.Any(y => y.Name.Name == name) && TargetAssemblyDefinition.Name.Name != name && !TargetAssemblyMainModule.AssemblyReferences.Any(y => y.Name == name && z.Version == y.Version))
                 {
                     // TODO: fix .NET runtime references?
                     // - to target a specific runtime version or


### PR DESCRIPTION
Not sure if this effects de-duping, but allowing two different versions of the same assembly to be referenced by the final artifact.
