### PR TITLE
Explicit error when a field/module is not found

### DIFF
--- a/ILRepack/ReferenceFixator.cs
+++ b/ILRepack/ReferenceFixator.cs
@@ -37,7 +37,7 @@ namespace ILRepacking
 
         private ModuleReference Fix(ModuleReference moduleRef)
         {
-            ModuleReference nmr = repack.TargetAssemblyMainModule.ModuleReferences.First(x => x.Name == moduleRef.Name);
+            ModuleReference nmr = repack.TargetAssemblyMainModule.ModuleReferences.FirstOrDefault(x => x.Name == moduleRef.Name);
             if (nmr == null)
                 throw new NullReferenceException("referenced module not found: \"" + moduleRef.Name + "\".");
             return nmr;
@@ -48,7 +48,7 @@ namespace ILRepacking
             field.DeclaringType = Fix(field.DeclaringType);
             if (field.DeclaringType.IsDefinition && !field.IsDefinition)
             {
-                FieldDefinition def = ((TypeDefinition)field.DeclaringType).Fields.First(x => x.Name == field.Name);
+                FieldDefinition def = ((TypeDefinition)field.DeclaringType).Fields.FirstOrDefault(x => x.Name == field.Name);
                 if (def == null)
                     throw new NullReferenceException("Field \"" + field + "\" not found in type \"" + field.DeclaringType + "\".");
                 return def;


### PR DESCRIPTION
Occurring when assembly A depends on B & C and B also depends on C (v2)
if a field has been renamed in C and is used in B, it won't be found.
Displays:
 NullReferenceException: Field "my.namespace.MyType my.namespace.MyType
::MyField" not found in type "my.namespace.MyType".
Instead of:
 InvalidOperationException: Sequence contains no matching element
