### PR TITLE
Fixed #58.

### DIFF
--- a/ILRepack/AssemblyDefinitionExtensions.cs
+++ b/ILRepack/AssemblyDefinitionExtensions.cs
@@ -1,0 +1,43 @@
+﻿using Mono.Cecil;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace ILRepacking
+{
+	public static class AssemblyDefinitionExtensions
+	{
+		public static string GetPortableProfileDirectory (this AssemblyDefinition assembly)
+		{
+			foreach (var custom in assembly.CustomAttributes) {
+				if (custom.AttributeType.FullName == "System.Runtime.Versioning.TargetFrameworkAttribute") {
+					var framework = custom.Properties [0].Argument.Value.ToString ();
+					if (!string.Equals (framework, ".NET Portable Subset")) {
+						return null;
+					}
+
+					var parts = custom.ConstructorArguments [0].Value.ToString ().Split (',');
+					var root = Environment.ExpandEnvironmentVariables (
+						                          Path.Combine (
+							                          "%systemdrive%",
+							                          "Program Files (x86)"));
+					return Environment.ExpandEnvironmentVariables (
+						Path.Combine (
+							"%systemdrive%", Path.Combine (
+							Directory.Exists (root) ? "Program Files (x86)" : "Program Files", 
+							Path.Combine("Reference Assemblies", 
+							Path.Combine("Microsoft", 
+							Path.Combine("Framework",
+							Path.Combine(parts [0],
+							Path.Combine((parts [1].Split ('=')) [1],
+                            Path.Combine("Profile",
+                            (parts [2].Split ('=')) [1]))))))))); 
+				}
+			}
+
+			return null;
+		}
+	}
+}

--- a/ILRepack/AssemblyDefinitionExtensions.cs
+++ b/ILRepack/AssemblyDefinitionExtensions.cs
@@ -13,16 +13,21 @@ namespace ILRepacking
 		{
 			foreach (var custom in assembly.CustomAttributes) {
 				if (custom.AttributeType.FullName == "System.Runtime.Versioning.TargetFrameworkAttribute") {
-					var framework = custom.Properties [0].Argument.Value.ToString ();
+					var displayName = custom.Properties.FirstOrDefault(item => item.Name == "FrameworkDisplayName").Argument.Value;
+					if (displayName == null) {
+						return null;
+					}
+
+					var framework = displayName.ToString ();
 					if (!string.Equals (framework, ".NET Portable Subset")) {
 						return null;
 					}
 
 					var parts = custom.ConstructorArguments [0].Value.ToString ().Split (',');
 					var root = Environment.ExpandEnvironmentVariables (
-						                          Path.Combine (
-							                          "%systemdrive%",
-							                          "Program Files (x86)"));
+						Path.Combine (
+							"%systemdrive%",
+							"Program Files (x86)"));
 					return Environment.ExpandEnvironmentVariables (
 						Path.Combine (
 							"%systemdrive%", Path.Combine (
@@ -32,8 +37,8 @@ namespace ILRepacking
 							Path.Combine("Framework",
 							Path.Combine(parts [0],
 							Path.Combine((parts [1].Split ('=')) [1],
-                            Path.Combine("Profile",
-                            (parts [2].Split ('=')) [1]))))))))); 
+							Path.Combine("Profile",
+							(parts [2].Split ('=')) [1]))))))))); 
 				}
 			}
 

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -43,6 +43,12 @@ namespace ILRepacking
         {
             foreach (var assemblyDefinition in mergedAssemblies)
             {
+                var path = assemblyDefinition.GetPortableProfileDirectory();
+                if (path != null && Directory.Exists(path))
+                {
+                    AddSearchDirectory(path);
+                }
+
                 base.RegisterAssembly(assemblyDefinition);
             }
         }
@@ -1669,7 +1675,13 @@ namespace ILRepacking
             foreach (MethodReference ov in meth.Overrides)
                 nm.Overrides.Add(Import(ov, nm));
 
-            CopySecurityDeclarations(meth.SecurityDeclarations, nm.SecurityDeclarations, nm);
+            try
+            {
+                CopySecurityDeclarations(meth.SecurityDeclarations, nm.SecurityDeclarations, nm);
+            }
+            catch
+            {}
+            
             CopyCustomAttributes(meth.CustomAttributes, nm.CustomAttributes, nm);
 
             nm.ReturnType = Import(meth.ReturnType, nm);

--- a/ILRepack/ILRepack.csproj
+++ b/ILRepack/ILRepack.csproj
@@ -64,6 +64,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssemblyDefinitionExtensions.cs" />
     <Compile Include="CommandLine.cs" />
     <Compile Include="ConfigMerger.cs" />
     <Compile Include="DocumentationMerger.cs" />


### PR DESCRIPTION
Initial attempt to fix this issue,
1. When assemblies are being registered, find PCL ones and add their profile paths to search paths.
2. Suppress `CopySecurityDeclarations` exceptions as PCL ones do not have security declarations.

Both changes are experimental as I only run through initial testing on simple cases.
