### PR TITLE
Changed to v4.5 for Parallel LINQ. Added ReadAssemblies performance test.

### DIFF
--- a/ILRepack.Tests/ILRepack.Tests.csproj
+++ b/ILRepack.Tests/ILRepack.Tests.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandLineTests.cs" />
-    <Compile Include="ILRepackTests.cs" />
+    <Compile Include="RepackAssembliesTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RepackLoggerTests.cs" />
     <Compile Include="RepackOptionsTests.cs" />

--- a/ILRepack.Tests/ILRepack.Tests.csproj
+++ b/ILRepack.Tests/ILRepack.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ILRepack.Tests</RootNamespace>
     <AssemblyName>ILRepack.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Moq">
@@ -47,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandLineTests.cs" />
+    <Compile Include="ILRepackTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RepackLoggerTests.cs" />
     <Compile Include="RepackOptionsTests.cs" />
@@ -55,6 +58,15 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker120.exe.config" />
+    <None Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker35.exe.config" />
+    <None Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker35.vshost.exe.config" />
+    <None Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker35.vshost.exe.manifest" />
+    <None Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker40.exe.config" />
+    <None Include="sharpdevelop\SharpDevelop.CheckMSBuild35Features.targets" />
+    <None Include="sharpdevelop\SharpDevelop.CodeAnalysis.targets" />
+    <None Include="sharpdevelop\SharpDevelop.exe.config" />
+    <None Include="sharpdevelop\SharpDevelop.TargetingPack.targets" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\cecil\Mono.Cecil.csproj">
@@ -65,6 +77,62 @@
       <Project>{4a253a60-d998-4ca2-b9d5-46567a2fbf80}</Project>
       <Name>ILRepack</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Resource Include="sharpdevelop\AvalonDock.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Resource>
+    <Resource Include="sharpdevelop\AvalonDock.pdb" />
+    <Content Include="sharpdevelop\dlls.txt" />
+    <Content Include="sharpdevelop\ICSharpCode.AvalonEdit.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.AvalonEdit.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.AvalonEdit.xml" />
+    <Content Include="sharpdevelop\ICSharpCode.Build.Tasks.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.Build.Tasks.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.Core.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.Core.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.Core.Presentation.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.Core.Presentation.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.Core.WinForms.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.Core.WinForms.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.Core.xml" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.Cecil.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.Cecil.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.Cecil.xml" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.CSharp.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.CSharp.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.CSharp.Refactoring.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.CSharp.Refactoring.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.CSharp.Refactoring.xml" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.CSharp.xml" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.xml" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.Xml.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.Xml.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.NRefactory.Xml.xml" />
+    <Content Include="sharpdevelop\ICSharpCode.Scripting.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.Scripting.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker120.exe" />
+    <Content Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker120.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker35.exe" />
+    <Content Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker35.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker35.vshost.exe" />
+    <Content Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker40.exe" />
+    <Content Include="sharpdevelop\ICSharpCode.SharpDevelop.BuildWorker40.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.SharpDevelop.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.SharpDevelop.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.SharpDevelop.Widgets.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.SharpDevelop.Widgets.pdb" />
+    <Content Include="sharpdevelop\ICSharpCode.TreeView.dll" />
+    <Content Include="sharpdevelop\ICSharpCode.TreeView.pdb" />
+    <Content Include="sharpdevelop\log4net.dll" />
+    <Content Include="sharpdevelop\Mono.Cecil.dll" />
+    <Content Include="sharpdevelop\Mono.Cecil.pdb" />
+    <Content Include="sharpdevelop\SharpDevelop.EnvDTE.dll" />
+    <Content Include="sharpdevelop\SharpDevelop.EnvDTE.pdb" />
+    <Content Include="sharpdevelop\SharpDevelop.exe" />
+    <Content Include="sharpdevelop\SharpDevelop.pdb" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ILRepack.Tests/ILRepackTests.cs
+++ b/ILRepack.Tests/ILRepackTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using ILRepacking;
+using Moq;
+using NUnit.Framework;
+
+namespace ILRepack.Tests
+{
+    [TestFixture]
+    class ILRepackTests
+    {
+        private RepackOptions repackOptions;
+        private ILRepacking.ILRepack repack;
+        private Mock<ILogger> logger;
+        private Mock<ICommandLine> commandLine;
+        private Mock<IFile> file;
+        private List<string> inputAssembliesPath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            logger = new Mock<ILogger>();
+            commandLine = new Mock<ICommandLine>();
+            file = new Mock<IFile>();
+
+            repackOptions = new RepackOptions(commandLine.Object, logger.Object, file.Object);
+            repack = new ILRepacking.ILRepack(repackOptions, logger.Object);
+
+            var inputAssemblies = new List<string> { "AvalonDock.dll", 
+                "ICsharpCode.AvalonEdit.dll", 
+                "ICSharpCode.Build.Tasks.dll", 
+                "ICSharpCode.Core.Presentation.dll",
+                "ICSharpCode.Core.WinForms.dll",
+                "ICSharpCode.Core.dll",
+                "ICSharpCode.NRefactory.CSharp.Refactoring.dll",
+                "ICSharpCode.NRefactory.CSharp.dll",
+                "ICSharpCode.NRefactory.Cecil.dll",
+                "ICSharpCode.NRefactory.Xml.dll",
+                "ICSharpCode.NRefactory.dll",
+                "ICSharpCode.SharpDevelop.Widgets.dll",
+                "ICSharpCode.SharpDevelop.dll",
+                "ICSharpCode.TreeView.dll",
+                "Mono.Cecil.dll",
+                "log4net.dll" };
+            var dir = "../../sharpdevelop/";
+            inputAssembliesPath = new List<string>();
+            foreach (var assembly in inputAssemblies)
+            {
+                inputAssembliesPath.Add(dir + assembly);
+            }
+        }
+
+        [Test]
+        public void TestReadAssemblies()
+        {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+            repackOptions.InputAssemblies = inputAssembliesPath.ToArray();
+
+            repack.ReadInputAssemblies();
+            stopwatch.Stop();
+            Console.WriteLine("Read assemblies: " + stopwatch.ElapsedMilliseconds);
+        }
+
+        [Test]
+        public void TestRepackReferences()
+        {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+            repackOptions.InputAssemblies = inputAssembliesPath.ToArray();
+
+            repack.ReadInputAssemblies();
+            repack.RepackReferences();
+            stopwatch.Stop();
+            Console.WriteLine("Read assemblies + repack references: " + stopwatch.ElapsedMilliseconds);
+        }
+    }
+}

--- a/ILRepack.Tests/ILRepackTests.cs
+++ b/ILRepack.Tests/ILRepackTests.cs
@@ -63,18 +63,5 @@ namespace ILRepack.Tests
             stopwatch.Stop();
             Console.WriteLine("Read assemblies: " + stopwatch.ElapsedMilliseconds);
         }
-
-        [Test]
-        public void TestRepackReferences()
-        {
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
-            repackOptions.InputAssemblies = inputAssembliesPath.ToArray();
-
-            repack.ReadInputAssemblies();
-            repack.RepackReferences();
-            stopwatch.Stop();
-            Console.WriteLine("Read assemblies + repack references: " + stopwatch.ElapsedMilliseconds);
-        }
     }
 }

--- a/ILRepack.Tests/RepackAssembliesTests.cs
+++ b/ILRepack.Tests/RepackAssembliesTests.cs
@@ -11,8 +11,8 @@ namespace ILRepack.Tests
     [TestFixture]
     class ILRepackTests
     {
-        private RepackOptions repackOptions;
-        private ILRepacking.ILRepack repack;
+        private RepackOptions options;
+        private RepackAssemblies assemblies;
         private Mock<ILogger> logger;
         private Mock<ICommandLine> commandLine;
         private Mock<IFile> file;
@@ -25,8 +25,8 @@ namespace ILRepack.Tests
             commandLine = new Mock<ICommandLine>();
             file = new Mock<IFile>();
 
-            repackOptions = new RepackOptions(commandLine.Object, logger.Object, file.Object);
-            repack = new ILRepacking.ILRepack(repackOptions, logger.Object);
+            options = new RepackOptions(commandLine.Object, logger.Object, file.Object);
+            assemblies = new RepackAssemblies(options, logger.Object, file.Object);
 
             var inputAssemblies = new List<string> { "AvalonDock.dll", 
                 "ICsharpCode.AvalonEdit.dll", 
@@ -57,9 +57,9 @@ namespace ILRepack.Tests
         {
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
-            repackOptions.InputAssemblies = inputAssembliesPath.ToArray();
+            options.InputAssemblies = inputAssembliesPath.ToArray();
 
-            repack.ReadInputAssemblies();
+            assemblies.ReadInputAssemblies();
             stopwatch.Stop();
             Console.WriteLine("Read assemblies: " + stopwatch.ElapsedMilliseconds);
         }

--- a/ILRepack.Tests/RepackAssembliesTests.cs
+++ b/ILRepack.Tests/RepackAssembliesTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Runtime.Remoting.Metadata.W3cXsd2001;
 using ILRepacking;
 using Moq;
 using NUnit.Framework;
@@ -57,6 +59,15 @@ namespace ILRepack.Tests
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
             options.InputAssemblies = inputAssembliesPath.ToArray();
+            options.DebugInfo = true;
+            foreach (var path in options.InputAssemblies)
+            {
+                file.Setup(f => f.Exists(Path.ChangeExtension(path, "pdb"))).Returns(true);
+                file.Setup(f => f.Exists(path)).Returns(true);
+            }
+            file.Setup(f => f.Exists("log4net.pdb")).Returns(false);
+            file.Setup(f => f.Exists("log4net.dll.mdb")).Returns(false);
+            logger.Setup(l => l.INFO(It.IsAny<string>())).Callback<string>(Console.WriteLine);
 
             assemblies.ReadInputAssemblies();
             stopwatch.Stop();

--- a/ILRepack.Tests/RepackAssembliesTests.cs
+++ b/ILRepack.Tests/RepackAssembliesTests.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.Remoting.Metadata.W3cXsd2001;
 using ILRepacking;
 using Moq;
 using NUnit.Framework;
+using ILRepack = ILRepacking.ILRepack;
 
 namespace ILRepack.Tests
 {
@@ -56,22 +56,10 @@ namespace ILRepack.Tests
         [Test]
         public void TestReadAssemblies()
         {
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
             options.InputAssemblies = inputAssembliesPath.ToArray();
             options.DebugInfo = true;
-            foreach (var path in options.InputAssemblies)
-            {
-                file.Setup(f => f.Exists(Path.ChangeExtension(path, "pdb"))).Returns(true);
-                file.Setup(f => f.Exists(path)).Returns(true);
-            }
-            file.Setup(f => f.Exists("log4net.pdb")).Returns(false);
-            file.Setup(f => f.Exists("log4net.dll.mdb")).Returns(false);
-            logger.Setup(l => l.INFO(It.IsAny<string>())).Callback<string>(Console.WriteLine);
 
             assemblies.ReadInputAssemblies();
-            stopwatch.Stop();
-            Console.WriteLine("Read assemblies: " + stopwatch.ElapsedMilliseconds);
         }
     }
 }

--- a/ILRepack.Tests/RepackAssembliesTests.cs
+++ b/ILRepack.Tests/RepackAssembliesTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using ILRepacking;
 using Moq;
 using NUnit.Framework;
@@ -9,7 +8,7 @@ using NUnit.Framework;
 namespace ILRepack.Tests
 {
     [TestFixture]
-    class ILRepackTests
+    class RepackAssembliesTests
     {
         private RepackOptions options;
         private RepackAssemblies assemblies;

--- a/ILRepack/Application.cs
+++ b/ILRepack/Application.cs
@@ -10,7 +10,10 @@ namespace ILRepacking
             ICommandLine commandLine = new CommandLine(args);
             ILogger logger = new RepackLogger();
             IFile file = new FileWrapper();
+
             RepackOptions options = new RepackOptions(commandLine, logger, file);
+            RepackAssemblies assemblies = new RepackAssemblies(options, logger, file);
+
             int returnCode = -1;
             try
             {
@@ -30,7 +33,9 @@ namespace ILRepacking
                     logger.ShouldLogVerbose = options.LogVerbose;
                 }
 
-                ILRepack repack = new ILRepack(options, logger);
+                assemblies.ReadInputAssemblies();
+
+                ILRepack repack = new ILRepack(options, logger, assemblies);
 
                 repack.Repack();
                 returnCode = 0;

--- a/ILRepack/Application.cs
+++ b/ILRepack/Application.cs
@@ -19,7 +19,9 @@ namespace ILRepacking
                     Usage();
                     Exit(2);
                 }
+
                 options.Parse();
+                options.ParseProperties();
 
                 //TODO: Open the Logger before the parse
                 if (logger.Open(options.LogFile))
@@ -29,6 +31,7 @@ namespace ILRepacking
                 }
 
                 ILRepack repack = new ILRepack(options, logger);
+
                 repack.Repack();
                 returnCode = 0;
             }

--- a/ILRepack/ConfigMerger.cs
+++ b/ILRepack/ConfigMerger.cs
@@ -27,7 +27,7 @@ namespace ILRepacking
             try
             {
                 var validConfigFiles = new List<string>();
-                foreach (string assembly in repack.Assemblies.MergedAssemblyFiles)
+                foreach (string assembly in repack.Assemblies.MergedAssemblyFileNames)
                 {
                     string assemblyConfig = assembly + ".config";
                     if (!File.Exists(assemblyConfig)) 

--- a/ILRepack/ConfigMerger.cs
+++ b/ILRepack/ConfigMerger.cs
@@ -27,7 +27,7 @@ namespace ILRepacking
             try
             {
                 var validConfigFiles = new List<string>();
-                foreach (string assembly in repack.MergedAssemblyFiles)
+                foreach (string assembly in repack.Assemblies.MergedAssemblyFiles)
                 {
                     string assemblyConfig = assembly + ".config";
                     if (!File.Exists(assemblyConfig)) 

--- a/ILRepack/DocumentationMerger.cs
+++ b/ILRepack/DocumentationMerger.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using System.Xml.XPath;
-using Mono.Cecil;
 
 namespace ILRepacking
 {
@@ -30,7 +29,7 @@ namespace ILRepacking
             {
                 var validXmlFiles = new List<XmlDocument>();
                 XmlDocument doc;
-                foreach (string assembly in repack.Assemblies.MergedAssemblyFiles)
+                foreach (string assembly in repack.Assemblies.MergedAssemblyFileNames)
                 {
                     string assemblyDoc = Path.ChangeExtension(assembly, ".xml");
                     if (File.Exists (assemblyDoc))

--- a/ILRepack/DocumentationMerger.cs
+++ b/ILRepack/DocumentationMerger.cs
@@ -30,7 +30,7 @@ namespace ILRepacking
             {
                 var validXmlFiles = new List<XmlDocument>();
                 XmlDocument doc;
-                foreach (string assembly in repack.MergedAssemblyFiles)
+                foreach (string assembly in repack.Assemblies.MergedAssemblyFiles)
                 {
                     string assemblyDoc = Path.ChangeExtension(assembly, ".xml");
                     if (File.Exists (assemblyDoc))
@@ -53,7 +53,7 @@ namespace ILRepacking
                 root.AppendChild(node);
                 var node2 = doc.CreateElement("name");
                 node.AppendChild(node2);
-                node2.AppendChild(doc.CreateTextNode(repack.TargetAssemblyDefinition.Name.Name));
+                node2.AppendChild(doc.CreateTextNode(repack.Assemblies.TargetAssemblyDefinition.Name.Name));
 
                 // members
                 node = doc.CreateElement("members");

--- a/ILRepack/IKVMLineIndexer.cs
+++ b/ILRepack/IKVMLineIndexer.cs
@@ -30,7 +30,7 @@ namespace ILRepacking
         {
             get
             {
-                return repack.TargetAssemblyMainModule;
+                return repack.Assemblies.TargetAssemblyDefinition.MainModule;
             }
         }
 
@@ -152,7 +152,7 @@ namespace ILRepacking
             if (!repack.Options.LineIndexation)
                 return;
 
-            ikvmRuntimeReference = repack.TargetAssemblyMainModule.AssemblyReferences.FirstOrDefault(r => r.Name == "IKVM.Runtime");
+            ikvmRuntimeReference = repack.Assemblies.TargetAssemblyDefinition.MainModule.AssemblyReferences.FirstOrDefault(r => r.Name == "IKVM.Runtime");
             if (ikvmRuntimeReference == null && repack.Options.LineIndexation)
             {
                 ikvmRuntimeReference = repack.Options.GlobalAssemblyResolver.Resolve("IKVM.Runtime").MainModule;

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -101,16 +101,7 @@ namespace ILRepacking
             mappingHandler = new MappingHandler();
             bool hadStrongName = Assemblies.PrimaryAssemblyDefinition.Name.HasPublicKey;
 
-            ModuleKind kind = Assemblies.PrimaryAssemblyDefinition.MainModule.Kind;
-            if (Options.TargetKind.HasValue)
-            {
-                switch (Options.TargetKind.Value)
-                {
-                    case Kind.Dll: kind = ModuleKind.Dll; break;
-                    case Kind.Exe: kind = ModuleKind.Console; break;
-                    case Kind.WinExe: kind = ModuleKind.Windows; break;
-                }
-            }
+            var kind = Assemblies.GetTargetModuleKind();
             var runtime = Assemblies.GetTargetRuntime();
             platformFixer.ParseTargetPlatformDirectory(runtime, Options.TargetPlatformDirectory);
 

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -75,19 +75,8 @@ namespace ILRepacking
 
         protected TargetRuntime ParseTargetPlatform()
         {
-            TargetRuntime runtime = Assemblies.PrimaryAssemblyDefinition.MainModule.Runtime;
-            if (Options.TargetPlatformVersion != null)
-            {
-                switch (Options.TargetPlatformVersion)
-                {
-                    case "v1": runtime = TargetRuntime.Net_1_0; break;
-                    case "v1.1": runtime = TargetRuntime.Net_1_1; break;
-                    case "v2": runtime = TargetRuntime.Net_2_0; break;
-                    case "v4": runtime = TargetRuntime.Net_4_0; break;
-                    default: throw new ArgumentException("Invalid TargetPlatformVersion: \"" + Options.TargetPlatformVersion + "\".");
-                }
-                platformFixer.ParseTargetPlatformDirectory(runtime, Options.TargetPlatformDirectory);
-            }
+            var runtime = Assemblies.GetTargetRuntime();
+            platformFixer.ParseTargetPlatformDirectory(runtime, Options.TargetPlatformDirectory);
             return runtime;
         }
 

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -74,15 +74,14 @@ namespace ILRepacking
             Repack();
         }
 
-        private void ReadInputAssemblies()
+        public void ReadInputAssemblies()
         {
             MergedAssemblyFiles = Options.InputAssemblies.SelectMany(ResolveFile).Distinct().ToList();
             OtherAssemblies = new List<AssemblyDefinition>();
-            // TODO: this could be parallelized to gain speed
+
             var primary = MergedAssemblyFiles.FirstOrDefault();
-            foreach (string assembly in MergedAssemblyFiles)
+            foreach (var result in MergedAssemblyFiles.Select(assembly => ReadInputAssembly(assembly, primary == assembly)).AsParallel())
             {
-                var result = ReadInputAssembly(assembly, primary == assembly);
                 if (result.IsPrimary)
                 {
                     PrimaryAssemblyDefinition = result.Definition;

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -67,6 +67,8 @@ namespace ILRepacking
         {
             Options = options;
             Logger = logger;
+
+            reflectionHelper = new ReflectionHelper(this);
         }
 
         public void Merge()
@@ -173,7 +175,6 @@ namespace ILRepacking
             SameAsPrimaryAssembly
         }
 
-
         protected TargetRuntime ParseTargetPlatform()
         {
             TargetRuntime runtime = PrimaryAssemblyMainModule.Runtime;
@@ -214,9 +215,6 @@ namespace ILRepacking
         /// </summary>
         public void Repack()
         {
-            reflectionHelper = new ReflectionHelper(this);
-            Options.ParseProperties();
-
             // Read input assemblies only after all properties are set.
             ReadInputAssemblies();
             Options.GlobalAssemblyResolver.RegisterAssemblies(MergedAssemblies);

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -73,13 +73,6 @@ namespace ILRepacking
             SameAsPrimaryAssembly
         }
 
-        protected TargetRuntime ParseTargetPlatform()
-        {
-            var runtime = Assemblies.GetTargetRuntime();
-            platformFixer.ParseTargetPlatformDirectory(runtime, Options.TargetPlatformDirectory);
-            return runtime;
-        }
-
         /// <summary>
         /// Check if a type's FullName matches a Reges to exclude it from internalizing.
         /// </summary>
@@ -118,7 +111,8 @@ namespace ILRepacking
                     case Kind.WinExe: kind = ModuleKind.Windows; break;
                 }
             }
-            TargetRuntime runtime = ParseTargetPlatform();
+            var runtime = Assemblies.GetTargetRuntime();
+            platformFixer.ParseTargetPlatformDirectory(runtime, Options.TargetPlatformDirectory);
 
             // change assembly's name to correspond to the file we create
             string mainModuleName = Path.GetFileNameWithoutExtension(Options.OutputFile);

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -97,12 +97,13 @@ namespace ILRepacking
         {
             Options.GlobalAssemblyResolver.RegisterAssemblies(Assemblies.MergedAssemblies);
 
-            platformFixer = new PlatformFixer(Assemblies.PrimaryAssemblyDefinition.MainModule.Runtime);
             mappingHandler = new MappingHandler();
             bool hadStrongName = Assemblies.PrimaryAssemblyDefinition.Name.HasPublicKey;
 
             var kind = Assemblies.GetTargetModuleKind();
             var runtime = Assemblies.GetTargetRuntime();
+
+            platformFixer = new PlatformFixer(Assemblies.PrimaryAssemblyDefinition.MainModule.Runtime);
             platformFixer.ParseTargetPlatformDirectory(runtime, Options.TargetPlatformDirectory);
 
             // change assembly's name to correspond to the file we create

--- a/ILRepack/ILRepack.csproj
+++ b/ILRepack/ILRepack.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReferenceFixator.cs" />
     <Compile Include="ReflectionHelper.cs" />
+    <Compile Include="RepackAssemblies.cs" />
     <Compile Include="RepackLogger.cs" />
     <Compile Include="RepackOptions.cs" />
     <Compile Include="RepackAssemblyResolver.cs" />

--- a/ILRepack/ILRepack.csproj
+++ b/ILRepack/ILRepack.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ILRepacking</RootNamespace>
     <AssemblyName>ILRepack</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <StartupObject>ILRepacking.Application</StartupObject>
     <PublishUrl>publish\</PublishUrl>
@@ -38,6 +38,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -46,6 +47,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Posix">

--- a/ILRepack/ReferenceFixator.cs
+++ b/ILRepack/ReferenceFixator.cs
@@ -37,7 +37,7 @@ namespace ILRepacking
 
         private ModuleReference Fix(ModuleReference moduleRef)
         {
-            ModuleReference nmr = repack.TargetAssemblyMainModule.ModuleReferences.FirstOrDefault(x => x.Name == moduleRef.Name);
+            ModuleReference nmr = repack.Assemblies.TargetAssemblyDefinition.MainModule.ModuleReferences.FirstOrDefault(x => x.Name == moduleRef.Name);
             if (nmr == null)
                 throw new NullReferenceException("referenced module not found: \"" + moduleRef.Name + "\".");
             return nmr;
@@ -228,12 +228,12 @@ namespace ILRepacking
                         }
                     }
                 }
-                if ((repack.TargetAssemblyMainModule.Runtime == TargetRuntime.Net_1_0) || (repack.TargetAssemblyMainModule.Runtime == TargetRuntime.Net_1_1))
+                if ((repack.Assemblies.TargetAssemblyDefinition.MainModule.Runtime == TargetRuntime.Net_1_0) || (repack.Assemblies.TargetAssemblyDefinition.MainModule.Runtime == TargetRuntime.Net_1_1))
                 {
                     SecurityDeclaration[] sdArray = securitydeclarations.ToArray();
                     securitydeclarations.Clear();
                     foreach (SecurityDeclaration sd in sdArray)
-                        securitydeclarations.Add(PermissionsetHelper.Permission2XmlSet(sd, repack.TargetAssemblyMainModule));
+                        securitydeclarations.Add(PermissionsetHelper.Permission2XmlSet(sd, repack.Assemblies.TargetAssemblyDefinition.MainModule));
                 }
             }
         }

--- a/ILRepack/ReferenceFixator.cs
+++ b/ILRepack/ReferenceFixator.cs
@@ -207,10 +207,10 @@ namespace ILRepacking
                             {
                                 if (prop.Name == "PublicKeyBlob")
                                 {
-                                    if (repack.TargetAssemblyDefinition.Name.HasPublicKey)
+                                    if (repack.Assemblies.TargetAssemblyDefinition.Name.HasPublicKey)
                                     {
                                         if (targetAssemblyPublicKeyBlobString == null)
-                                            foreach (byte b in repack.TargetAssemblyDefinition.Name.PublicKey)
+                                            foreach (byte b in repack.Assemblies.TargetAssemblyDefinition.Name.PublicKey)
                                                 targetAssemblyPublicKeyBlobString += b.ToString("X").PadLeft(2, '0');
                                         if (prop.Argument.Type.FullName != "System.String")
                                             throw new NotSupportedException("Invalid type of argument, expected string");

--- a/ILRepack/RepackAssemblies.cs
+++ b/ILRepack/RepackAssemblies.cs
@@ -14,12 +14,13 @@ namespace ILRepacking
         private readonly ILogger logger;
         private readonly IFile file;
 
-        internal List<string> MergedAssemblyFiles { get; set; }
-        internal string PrimaryAssemblyFile { get; set; }
+        internal List<string> MergedAssemblyFileNames { get; set; }
+        internal string PrimaryAssemblyFileName { get; set; }
         // contains all 'other' assemblies, but not the primary fileName
         internal List<AssemblyDefinition> OtherAssemblies { get; set; }
         // contains all assemblies, primary and 'other'
         internal List<AssemblyDefinition> MergedAssemblies { get; set; }
+
         internal AssemblyDefinition TargetAssemblyDefinition { get; set; }
         internal AssemblyDefinition PrimaryAssemblyDefinition { get; set; }
 
@@ -36,14 +37,14 @@ namespace ILRepacking
 
         public void ReadInputAssemblies()
         {
-            MergedAssemblyFiles = options.InputAssemblies.SelectMany(ResolveFile).Distinct().ToList();
+            MergedAssemblyFileNames = options.InputAssemblies.SelectMany(ResolveFile).Distinct().ToList();
             OtherAssemblies = new List<AssemblyDefinition>();
             MergedAssemblies = new List<AssemblyDefinition>();
 
-            PrimaryAssemblyFile = MergedAssemblyFiles.FirstOrDefault();
-            foreach (var assemblyDefinition in MergedAssemblyFiles.AsParallel().Select(ReadInputAssembly))
+            PrimaryAssemblyFileName = MergedAssemblyFileNames.FirstOrDefault();
+            foreach (var assemblyDefinition in MergedAssemblyFileNames.AsParallel().Select(ReadInputAssembly))
             {
-                if (result.Definition.Name.Name == Path.GetFileNameWithoutExtension(PrimaryAssemblyFile))
+                if (assemblyDefinition.Name.Name == Path.GetFileNameWithoutExtension(PrimaryAssemblyFileName))
                 {
                     PrimaryAssemblyDefinition = assemblyDefinition;
                 }

--- a/ILRepack/RepackAssemblies.cs
+++ b/ILRepack/RepackAssemblies.cs
@@ -83,14 +83,14 @@ namespace ILRepacking
                 }
                 else
                 {
-                    logger.ERROR("Failed to load fileName " + fileName);
+                    logger.ERROR("Failed to load assembly" + fileName);
                     throw;
                 }
             }
             if (!options.AllowZeroPeKind && (assemblyDefinition.MainModule.Attributes & ModuleAttributes.ILOnly) == 0)
             {
-                logger.ERROR("Failed to load fileName " + fileName);
-                throw new ArgumentException("Failed to load fileName with Zero PeKind: " + fileName);
+                logger.ERROR("Failed to load assembly" + fileName);
+                throw new ArgumentException("Failed to load assembly with Zero PeKind: " + fileName);
             }
 
             return assemblyDefinition;
@@ -151,7 +151,7 @@ namespace ILRepacking
         {
             var kind = GetTargetModuleKind();
             var runtime = GetTargetRuntime();
-            // change fileName's name to correspond to the file we create
+            // change assembly's name to correspond to the file we create
             string mainModuleName = Path.GetFileNameWithoutExtension(options.OutputFile);
             if (TargetAssemblyDefinition == null)
             {
@@ -210,7 +210,7 @@ namespace ILRepacking
 
         // Real stuff below //
         // These methods are somehow a merge between the clone methods of Cecil 0.6 and the import ones of 0.9
-        // They use Cecil's MetaDataImporter to rebase imported stuff into the new fileName, but then another pass is required
+        // They use Cecil's MetaDataImporter to rebase imported stuff into the new assembly, but then another pass is required
         //  to clean the TypeRefs Cecil keeps around (although the generated IL would be kind-o valid without, whatever 'valid' means)
         private AssemblyNameDefinition Clone(AssemblyNameDefinition assemblyName)
         {
@@ -261,7 +261,7 @@ namespace ILRepacking
                 }
                 else if (!IsVersionInfoRes(parents, exist))
                 {
-                    logger.WARN(string.Format("Duplicate Win32 resource with id={0}, parents=[{1}], name={2} in fileName {3}, ignoring", entry.Id, string.Join(",", parents.Select(p => p.Name ?? p.Id.ToString()).ToArray()), entry.Name, ass.Name));
+                    logger.WARN(string.Format("Duplicate Win32 resource with id={0}, parents=[{1}], name={2} in assembly {3}, ignoring", entry.Id, string.Join(",", parents.Select(p => p.Name ?? p.Id.ToString()).ToArray()), entry.Name, ass.Name));
                 }
                 return;
             }

--- a/ILRepack/RepackAssemblies.cs
+++ b/ILRepack/RepackAssemblies.cs
@@ -118,5 +118,31 @@ namespace ILRepacking
             if (String.IsNullOrEmpty(dir)) dir = Directory.GetCurrentDirectory();
             return Directory.GetFiles(Path.GetFullPath(dir), Path.GetFileName(s));
         }
+
+        public TargetRuntime GetTargetRuntime()
+        {
+            var runtime = PrimaryAssemblyDefinition.MainModule.Runtime;
+            if (options.TargetPlatformVersion == null)
+                return runtime;
+
+            switch (options.TargetPlatformVersion)
+            {
+                case "v1":
+                    runtime = TargetRuntime.Net_1_0;
+                    break;
+                case "v1.1":
+                    runtime = TargetRuntime.Net_1_1;
+                    break;
+                case "v2":
+                    runtime = TargetRuntime.Net_2_0;
+                    break;
+                case "v4":
+                    runtime = TargetRuntime.Net_4_0;
+                    break;
+                default:
+                    throw new ArgumentException("Invalid TargetPlatformVersion: \"" + options.TargetPlatformVersion + "\".");
+            }
+            return runtime;
+        }
     }
 }

--- a/ILRepack/RepackAssemblies.cs
+++ b/ILRepack/RepackAssemblies.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mono.Cecil;
+
+namespace ILRepacking
+{
+    class RepackAssemblies
+    {
+        private readonly RepackOptions options;
+        private readonly ILogger logger;
+        private readonly IFile file;
+
+        internal List<string> MergedAssemblyFiles { get; set; }
+        internal string PrimaryAssemblyFile { get; set; }
+        // contains all 'other' assemblies, but not the primary assembly
+        internal List<AssemblyDefinition> OtherAssemblies { get; set; }
+        // contains all assemblies, primary and 'other'
+        internal List<AssemblyDefinition> MergedAssemblies { get; set; }
+        internal AssemblyDefinition TargetAssemblyDefinition { get; set; }
+        internal AssemblyDefinition PrimaryAssemblyDefinition { get; set; }
+
+        public RepackAssemblies(RepackOptions options, ILogger logger, IFile file)
+        {
+            this.options = options;
+            this.logger = logger;
+            this.file = file;
+        }
+
+        public void ReadInputAssemblies()
+        {
+            MergedAssemblyFiles = options.InputAssemblies.SelectMany(ResolveFile).Distinct().ToList();
+            OtherAssemblies = new List<AssemblyDefinition>();
+
+            var primary = MergedAssemblyFiles.FirstOrDefault();
+            foreach (var result in MergedAssemblyFiles.Select(assembly => ReadInputAssembly(assembly, primary == assembly)).AsParallel())
+            {
+                if (result.IsPrimary)
+                {
+                    PrimaryAssemblyDefinition = result.Definition;
+                    PrimaryAssemblyFile = result.Assembly;
+                }
+                else
+                    OtherAssemblies.Add(result.Definition);
+
+                // prevent writing PDB if we haven't read any
+                options.DebugInfo &= result.SymbolsRead;
+            }
+
+            MergedAssemblies = new List<AssemblyDefinition>(OtherAssemblies);
+            MergedAssemblies.Add(PrimaryAssemblyDefinition);
+        }
+
+        private AssemblyDefinitionContainer ReadInputAssembly(string assembly, bool isPrimary)
+        {
+            logger.INFO("Adding assembly for merge: " + assembly);
+            try
+            {
+                ReaderParameters rp = new ReaderParameters(ReadingMode.Immediate) {AssemblyResolver = options.GlobalAssemblyResolver};
+                // read PDB/MDB?
+                if (options.DebugInfo && (file.Exists(Path.ChangeExtension(assembly, "pdb")) || file.Exists(assembly + ".mdb")))
+                {
+                    rp.ReadSymbols = true;
+                }
+                AssemblyDefinition mergeAsm;
+                try
+                {
+                    mergeAsm = AssemblyDefinition.ReadAssembly(assembly, rp);
+                }
+                catch
+                {
+                    // cope with invalid symbol file
+                    if (rp.ReadSymbols)
+                    {
+                        rp.ReadSymbols = false;
+                        mergeAsm = AssemblyDefinition.ReadAssembly(assembly, rp);
+                        logger.INFO("Failed to load debug information for " + assembly);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                if (!options.AllowZeroPeKind && (mergeAsm.MainModule.Attributes & ModuleAttributes.ILOnly) == 0)
+                    throw new ArgumentException("Failed to load assembly with Zero PeKind: " + assembly);
+
+                return new AssemblyDefinitionContainer
+                {
+                    Assembly = assembly,
+                    Definition = mergeAsm,
+                    IsPrimary = isPrimary,
+                    SymbolsRead = rp.ReadSymbols
+                };
+            }
+            catch
+            {
+                logger.ERROR("Failed to load assembly " + assembly);
+                throw;
+            }
+        }
+
+        public class AssemblyDefinitionContainer
+        {
+            public bool SymbolsRead { get; set; }
+            public AssemblyDefinition Definition { get; set; }
+            public string Assembly { get; set; }
+            public bool IsPrimary { get; set; }
+        }
+
+        private IEnumerable<string> ResolveFile(string s)
+        {
+            if (!options.AllowWildCards || s.IndexOfAny(new[] { '*', '?' }) == -1)
+                return new[] { s };
+            if (Path.GetDirectoryName(s).IndexOfAny(new[] { '*', '?' }) != -1)
+                throw new Exception("Invalid path: " + s);
+            string dir = Path.GetDirectoryName(s);
+            if (String.IsNullOrEmpty(dir)) dir = Directory.GetCurrentDirectory();
+            return Directory.GetFiles(Path.GetFullPath(dir), Path.GetFileName(s));
+        }
+    }
+}

--- a/ILRepack/RepackAssemblies.cs
+++ b/ILRepack/RepackAssemblies.cs
@@ -144,5 +144,19 @@ namespace ILRepacking
             }
             return runtime;
         }
+
+        public ModuleKind GetTargetModuleKind()
+        {
+            ModuleKind kind = PrimaryAssemblyDefinition.MainModule.Kind;
+            if (options.TargetKind.HasValue)
+            {
+                switch (options.TargetKind.Value)
+                {
+                    case ILRepack.Kind.Dll: kind = ModuleKind.Dll; break;
+                    case ILRepack.Kind.Exe: kind = ModuleKind.Console; break;
+                    case ILRepack.Kind.WinExe: kind = ModuleKind.Windows; break;
+                }
+            }
+        }
     }
 }

--- a/ILRepack/RepackAssemblies.cs
+++ b/ILRepack/RepackAssemblies.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Mono.Cecil;
+using Mono.Cecil.PE;
 
 namespace ILRepacking
 {
@@ -21,11 +23,17 @@ namespace ILRepacking
         internal AssemblyDefinition TargetAssemblyDefinition { get; set; }
         internal AssemblyDefinition PrimaryAssemblyDefinition { get; set; }
 
+        internal Dictionary<AssemblyDefinition, int> AspOffsets { get; set; }
+
+        
+
         public RepackAssemblies(RepackOptions options, ILogger logger, IFile file)
         {
             this.options = options;
             this.logger = logger;
             this.file = file;
+
+             AspOffsets = new Dictionary<AssemblyDefinition, int>();
         }
 
         public void ReadInputAssemblies()
@@ -157,6 +165,150 @@ namespace ILRepacking
                     case ILRepack.Kind.WinExe: kind = ModuleKind.Windows; break;
                 }
             }
+            return kind;
+        }
+
+        public void ParseTargetAssemblyDefinition()
+        {
+            var kind = GetTargetModuleKind();
+            var runtime = GetTargetRuntime();
+            // change assembly's name to correspond to the file we create
+            string mainModuleName = Path.GetFileNameWithoutExtension(options.OutputFile);
+            if (TargetAssemblyDefinition == null)
+            {
+                AssemblyNameDefinition asmName = Clone(PrimaryAssemblyDefinition.Name);
+                asmName.Name = mainModuleName;
+                TargetAssemblyDefinition = AssemblyDefinition.CreateAssembly(asmName, mainModuleName,
+                    new ModuleParameters()
+                        {
+                            Kind = kind,
+                            Architecture = PrimaryAssemblyDefinition.MainModule.Architecture,
+                            AssemblyResolver = options.GlobalAssemblyResolver,
+                            Runtime = runtime
+                        });
+            }
+            else
+            {
+                // TODO: does this work or is there more to do?
+                TargetAssemblyDefinition.MainModule.Kind = kind;
+                TargetAssemblyDefinition.MainModule.Runtime = runtime;
+
+                TargetAssemblyDefinition.Name.Name = mainModuleName;
+                TargetAssemblyDefinition.MainModule.Name = mainModuleName;
+            }
+            // set the main module attributes
+            TargetAssemblyDefinition.MainModule.Attributes = PrimaryAssemblyDefinition.MainModule.Attributes;
+            TargetAssemblyDefinition.MainModule.Win32ResourceDirectory = MergeWin32Resources(PrimaryAssemblyDefinition.MainModule.Win32ResourceDirectory, OtherAssemblies.Select(x => x.MainModule).Select(x => x.Win32ResourceDirectory));
+
+            if (options.Version != null)
+                TargetAssemblyDefinition.Name.Version = options.Version;
+            // TODO: Win32 version/icon properties seem not to be copied... limitation in cecil 0.9x?
+            StrongNameKeyPair snkp = null;
+            if (options.KeyFile != null && File.Exists(options.KeyFile))
+            {
+                using (var stream = new FileStream(options.KeyFile, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    snkp = new StrongNameKeyPair(stream);
+                }
+                TargetAssemblyDefinition.Name.PublicKey = snkp.PublicKey;
+                TargetAssemblyDefinition.Name.Attributes |= AssemblyAttributes.PublicKey;
+                TargetAssemblyDefinition.MainModule.Attributes |= ModuleAttributes.StrongNameSigned;
+            }
+            else
+            {
+                TargetAssemblyDefinition.Name.PublicKey = null;
+                TargetAssemblyDefinition.MainModule.Attributes &= ~ModuleAttributes.StrongNameSigned;
+            }
+
+            var parameters = new WriterParameters();
+            if ((snkp != null) && !options.DelaySign)
+                parameters.StrongNameKeyPair = snkp;
+            // write PDB/MDB?
+            if (options.DebugInfo)
+                parameters.WriteSymbols = true;
+            TargetAssemblyDefinition.Write(options.OutputFile, parameters);
+        }
+
+        // Real stuff below //
+        // These methods are somehow a merge between the clone methods of Cecil 0.6 and the import ones of 0.9
+        // They use Cecil's MetaDataImporter to rebase imported stuff into the new assembly, but then another pass is required
+        //  to clean the TypeRefs Cecil keeps around (although the generated IL would be kind-o valid without, whatever 'valid' means)
+        private AssemblyNameDefinition Clone(AssemblyNameDefinition assemblyName)
+        {
+            AssemblyNameDefinition asmName = new AssemblyNameDefinition(assemblyName.Name, assemblyName.Version);
+            asmName.Attributes = assemblyName.Attributes;
+            asmName.Culture = assemblyName.Culture;
+            asmName.Hash = assemblyName.Hash;
+            asmName.HashAlgorithm = assemblyName.HashAlgorithm;
+            asmName.PublicKey = assemblyName.PublicKey;
+            asmName.PublicKeyToken = assemblyName.PublicKeyToken;
+            return asmName;
+        }
+
+        private ResourceDirectory MergeWin32Resources(ResourceDirectory primary, IEnumerable<ResourceDirectory> resources)
+        {
+            if (primary == null)
+                return null;
+            foreach (var ass in OtherAssemblies)
+            {
+                MergeDirectory(new List<ResourceEntry>(), primary, ass, ass.MainModule.Win32ResourceDirectory);
+            }
+            return primary;
+        }
+
+        private void MergeDirectory(List<ResourceEntry> parents, ResourceDirectory ret, AssemblyDefinition ass, ResourceDirectory directory)
+        {
+            foreach (var entry in directory.Entries)
+            {
+                var exist = ret.Entries.FirstOrDefault(x => entry.Name == null ? entry.Id == x.Id : entry.Name == x.Name);
+                if (exist == null)
+                    ret.Entries.Add(entry);
+                else
+                    MergeEntry(parents, exist, ass, entry);
+            }
+        }
+
+        private void MergeEntry(List<ResourceEntry> parents, ResourceEntry exist, AssemblyDefinition ass, ResourceEntry entry)
+        {
+            if (exist.Data != null && entry.Data != null)
+            {
+                if (IsAspRes(parents, exist))
+                {
+                    AspOffsets[ass] = exist.Data.Length;
+                    byte[] newData = new byte[exist.Data.Length + entry.Data.Length];
+                    Array.Copy(exist.Data, 0, newData, 0, exist.Data.Length);
+                    Array.Copy(entry.Data, 0, newData, exist.Data.Length, entry.Data.Length);
+                    exist.Data = newData;
+                }
+                else if (!IsVersionInfoRes(parents, exist))
+                {
+                    logger.WARN(string.Format("Duplicate Win32 resource with id={0}, parents=[{1}], name={2} in assembly {3}, ignoring", entry.Id, string.Join(",", parents.Select(p => p.Name ?? p.Id.ToString()).ToArray()), entry.Name, ass.Name));
+                }
+                return;
+            }
+            if (exist.Data != null || entry.Data != null)
+            {
+                logger.WARN("Inconsistent Win32 resources, ignoring");
+                return;
+            }
+            parents.Add(exist);
+            MergeDirectory(parents, exist.Directory, ass, entry.Directory);
+            parents.RemoveAt(parents.Count - 1);
+        }
+
+        public bool TryGetAspOffset(AssemblyDefinition assemblyDefinition, out int offset)
+        {
+            return AspOffsets.TryGetValue(assemblyDefinition, out offset);
+        }
+
+        private static bool IsAspRes(List<ResourceEntry> parents, ResourceEntry exist)
+        {
+            return exist.Id == 101 && parents.Count == 1 && parents[0].Id == 3771;
+        }
+
+        private static bool IsVersionInfoRes(List<ResourceEntry> parents, ResourceEntry exist)
+        {
+            return exist.Id == 0 && parents.Count == 2 && parents[0].Id == 16 && parents[1].Id == 1;
         }
     }
 }

--- a/ILRepack/app.config
+++ b/ILRepack/app.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v2.0.50727"/>
     <supportedRuntime version="v4.0"/>
   </startup>
 </configuration>


### PR DESCRIPTION
Opened this for discussion. What do you think of changing the target framework to 4.5 and using parallel linq on the enumerations? I think the changes could be minimal.

Made ILRepack.ReadAssemblies use AsParallel on my PC with 16 dlls from sharpdevelop and there's a decrease from 6 seconds to 4 seconds in execution. Will continue with RepackReferences.
