### PR TITLE
Skip the processing when no streams to merge

### DIFF
--- a/ILRepack/Steps/ResourceProcessing/BamlStreamCollector.cs
+++ b/ILRepack/Steps/ResourceProcessing/BamlStreamCollector.cs
@@ -60,6 +60,9 @@ namespace ILRepacking.Steps.ResourceProcessing
 
         public void Process(EmbeddedResource embeddedResource, ResourceWriter resourceWriter)
         {
+            if (_bamlStreams.Count == 0)
+                return;
+
             WriteCollectedBamlStreams(resourceWriter);
             PatchGenericThemesBaml(resourceWriter);
         }


### PR DESCRIPTION
This also ensures that ILRepack will work
properly on mono, by not having to code
for mono's ResourceWriter implementation.