### PR TITLE
API Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ IL Repack changelog
  * User Controls from libraries can now be used inside XAML files.
  * XAML Resource paths in `InitializeComponent()` methods are patched to reference the main assembly instead.
  * Support for styles, theming (`themes/generic.xml`) and inclusion of XAML files (via pack or non-pack URIs).
+* API has been cleaned up (with potential breaking changes, depending on the usage).

--- a/ILRepack.Tests/NuGet/TestHelpers.cs
+++ b/ILRepack.Tests/NuGet/TestHelpers.cs
@@ -33,13 +33,13 @@ namespace ILRepack.Tests.NuGet
 
         public static void DoRepackForCmd(IEnumerable<string> args)
         {
-            var repack = new ILRepacking.ILRepack(GetOptionsForCmd(args), TestHelpers.logger);
+            var repack = new ILRepacking.ILRepack(GetOptionsForCmd(args));
             repack.Repack();
         }
 
         public static RepackOptions GetOptionsForCmd(IEnumerable<string> args)
         {
-            ICommandLine commandLine = new CommandLine(args.Concat(new []{"/log"}).ToArray());
+            ICommandLine commandLine = new CommandLine(args.Concat(new[] { "/log" }).ToArray());
             RepackOptions options = new RepackOptions(commandLine, TestHelpers.logger, new FileWrapper());
             options.Parse();
             return options;
@@ -48,10 +48,10 @@ namespace ILRepack.Tests.NuGet
         public static void SaveAs(Stream input, string directory, string fileName)
         {
             var path = Path.Combine(directory, Path.GetFileName(fileName));
-            using (var stream = input) {
-                using (var file = new FileStream(path, FileMode.Create)) {
-                    stream.CopyTo(file);
-                }
+            using (var stream = input)
+            using (var file = new FileStream(path, FileMode.Create))
+            {
+                stream.CopyTo(file);
             }
         }
     }

--- a/ILRepack.Tests/RepackLoggerTests.cs
+++ b/ILRepack.Tests/RepackLoggerTests.cs
@@ -29,10 +29,10 @@ namespace ILRepack.Tests
             Assert.IsTrue(logger.Open("file.out"));
             logger.Close();
             const string message = "Only written to the console. No erorr is thrown.";
-            logger.ERROR(message);
-            logger.WARN(message);
-            logger.VERBOSE(message);
-            logger.INFO(message);
+            logger.Error(message);
+            logger.Warn(message);
+            logger.Verbose(message);
+            logger.Info(message);
         }
     }
 }

--- a/ILRepack.Tests/RepackOptionsTests.cs
+++ b/ILRepack.Tests/RepackOptionsTests.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using ILRepacking;
+﻿using ILRepacking;
 using Moq;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ILRepack.Tests
 {
@@ -215,7 +215,7 @@ namespace ILRepack.Tests
         {
             commandLine.Setup(cmd => cmd.Modifier("delaysign")).Returns(true);
             options.Parse();
-            repackLogger.Verify(logger => logger.WARN(It.IsAny<string>()));
+            repackLogger.Verify(logger => logger.Warn(It.IsAny<string>()));
         }
 
         [Test]
@@ -223,7 +223,7 @@ namespace ILRepack.Tests
         {
             commandLine.Setup(cmd => cmd.Modifier("allowmultiple")).Returns(true);
             options.Parse();
-            repackLogger.Verify(logger => logger.WARN(It.IsAny<string>()));
+            repackLogger.Verify(logger => logger.Warn(It.IsAny<string>()));
         }
 
         [Test]
@@ -233,15 +233,15 @@ namespace ILRepack.Tests
             commandLine.Setup(cmd => cmd.Option("attr")).Returns(attributeFile);
             commandLine.Setup(cmd => cmd.Modifier("copyattrs")).Returns(true);
             options.Parse();
-            repackLogger.Verify(logger => logger.WARN(It.IsAny<string>()));
+            repackLogger.Verify(logger => logger.Warn(It.IsAny<string>()));
         }
-        
+
         [Test]
         public void WithNoSetup__SetSearchDirectories__SetGlobalAssemblyResolver()
         {
             var dirs = new List<string> { "dir1", "dir2", "dir3" };
             options.SetSearchDirectories(dirs);
-            var searchDirs = dirs.Concat(new string[] { ".", "bin"});
+            var searchDirs = dirs.Concat(new string[] { ".", "bin" });
             CollectionAssert.AreEquivalent(searchDirs, options.GlobalAssemblyResolver.GetSearchDirectories());
         }
 
@@ -254,7 +254,7 @@ namespace ILRepack.Tests
             Assert.AreEqual(directory, options.TargetPlatformDirectory);
             Assert.AreEqual(version, options.TargetPlatformVersion);
         }
-        
+
         [Test]
         [ExpectedException(typeof(ArgumentException), ExpectedMessage = "No output file given.")]
         public void WithNoOutputFile__ParseProperties__ThrowException()

--- a/ILRepack.Tests/RepackOptionsTests.cs
+++ b/ILRepack.Tests/RepackOptionsTests.cs
@@ -37,7 +37,7 @@ namespace ILRepack.Tests
         {
             commandLine.Setup(cmd => cmd.HasNoOptions).Returns(false);
             commandLine.Setup(cmd => cmd.Modifier("?")).Returns(true);
-            Assert.IsTrue(options.ShouldShowUsage());
+            Assert.IsTrue(options.ShouldShowUsage);
         }
 
         [Test]
@@ -46,7 +46,7 @@ namespace ILRepack.Tests
             commandLine.Setup(cmd => cmd.HasNoOptions).Returns(false);
             commandLine.Setup(cmd => cmd.Modifier("?")).Returns(false);
             commandLine.Setup(cmd => cmd.Modifier("help")).Returns(true);
-            Assert.IsTrue(options.ShouldShowUsage());
+            Assert.IsTrue(options.ShouldShowUsage);
         }
 
         [Test]
@@ -56,7 +56,7 @@ namespace ILRepack.Tests
             commandLine.Setup(cmd => cmd.Modifier("?")).Returns(false);
             commandLine.Setup(cmd => cmd.Modifier("help")).Returns(true);
             commandLine.Setup(cmd => cmd.Modifier("h")).Returns(true);
-            Assert.IsTrue(options.ShouldShowUsage());
+            Assert.IsTrue(options.ShouldShowUsage);
         }
 
         [Test]
@@ -66,13 +66,13 @@ namespace ILRepack.Tests
             commandLine.Setup(cmd => cmd.Modifier("help")).Returns(false);
             commandLine.Setup(cmd => cmd.Modifier("h")).Returns(false);
             commandLine.Setup(cmd => cmd.HasNoOptions).Returns(true);
-            Assert.IsTrue(options.ShouldShowUsage());
+            Assert.IsTrue(options.ShouldShowUsage);
         }
 
         [Test]
         public void WithOptions_CallShouldShowUsage__ReturnFalse()
         {
-            Assert.IsFalse(options.ShouldShowUsage());
+            Assert.IsFalse(options.ShouldShowUsage);
         }
 
         [Test]

--- a/ILRepack.Tests/Steps/ResourceProcessing/BamlGeneratorTests.cs
+++ b/ILRepack.Tests/Steps/ResourceProcessing/BamlGeneratorTests.cs
@@ -46,7 +46,7 @@ namespace ILRepack.Tests.Steps.ResourceProcessing
             });
 
             Assert.That(modifiedDocument, new BamlDocumentMatcher(initialDocument));
-            logger.Verify(l => l.ERROR("Existing 'Themes/generic.xaml' in ClassLibrary is *not* a ResourceDictionary. " +
+            logger.Verify(l => l.Error("Existing 'Themes/generic.xaml' in ClassLibrary is *not* a ResourceDictionary. " +
                                        "This will prevent proper WPF application merging."));
         }
 

--- a/ILRepack/Application.cs
+++ b/ILRepack/Application.cs
@@ -14,7 +14,7 @@ namespace ILRepacking
             int returnCode = -1;
             try
             {
-                if (options.ShouldShowUsage())
+                if (options.ShouldShowUsage)
                 {
                     Usage();
                     Exit(2);

--- a/ILRepack/Application.cs
+++ b/ILRepack/Application.cs
@@ -2,7 +2,7 @@
 
 namespace ILRepacking
 {
-    public class Application
+    internal class Application
     {
         [STAThread]
         static int Main(string[] args)

--- a/ILRepack/Application.cs
+++ b/ILRepack/Application.cs
@@ -28,7 +28,7 @@ namespace ILRepacking
                     options.Log = true;
                 }
 
-                ILRepack repack = new ILRepack(options, logger);
+                ILRepack repack = new ILRepack(options);
                 repack.Repack();
                 returnCode = 0;
             }

--- a/ILRepack/ConfigMerger.cs
+++ b/ILRepack/ConfigMerger.cs
@@ -30,7 +30,7 @@ namespace ILRepacking
                 foreach (string assembly in repack.MergedAssemblyFiles)
                 {
                     string assemblyConfig = assembly + ".config";
-                    if (!File.Exists(assemblyConfig)) 
+                    if (!File.Exists(assemblyConfig))
                         continue;
                     var doc = new XmlDocument();
                     doc.Load(assemblyConfig);
@@ -55,7 +55,7 @@ namespace ILRepacking
             }
             catch (Exception e)
             {
-                repack.Logger.ERROR("Failed to merge configuration files: " + e);
+                repack.Logger.Error("Failed to merge configuration files: " + e);
             }
         }
     }

--- a/ILRepack/DocumentationMerger.cs
+++ b/ILRepack/DocumentationMerger.cs
@@ -33,14 +33,14 @@ namespace ILRepacking
                 foreach (string assembly in repack.MergedAssemblyFiles)
                 {
                     string assemblyDoc = Path.ChangeExtension(assembly, ".xml");
-                    if (File.Exists (assemblyDoc))
+                    if (File.Exists(assemblyDoc))
                     {
                         doc = new XmlDocument();
-                        doc.Load (assemblyDoc);
+                        doc.Load(assemblyDoc);
                         validXmlFiles.Add(doc);
                     }
                 }
-    			
+
                 if (validXmlFiles.Count == 0)
                     return;
 
@@ -64,7 +64,7 @@ namespace ILRepacking
                     while (iterator.MoveNext())
                     {
                         XPathNavigator navigator = iterator.Current;
-                        node.AppendChild(doc.ImportNode((XmlNode) navigator.UnderlyingObject, true));
+                        node.AppendChild(doc.ImportNode((XmlNode)navigator.UnderlyingObject, true));
                     }
                 }
 
@@ -76,7 +76,7 @@ namespace ILRepacking
             }
             catch (Exception e)
             {
-                repack.Logger.ERROR("Failed to merge documentation files: " + e);
+                repack.Logger.Error("Failed to merge documentation files: " + e);
             }
         }
     }

--- a/ILRepack/FileWrapper.cs
+++ b/ILRepack/FileWrapper.cs
@@ -2,7 +2,7 @@
 
 namespace ILRepacking
 {
-    public class FileWrapper : IFile
+    internal class FileWrapper : IFile
     {
         public bool Exists(string path)
         {

--- a/ILRepack/ICommandLine.cs
+++ b/ILRepack/ICommandLine.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace ILRepacking
 {
-    public interface ICommandLine
+    internal interface ICommandLine
     {
         string[] OtherAguments { get; }
 

--- a/ILRepack/IFile.cs
+++ b/ILRepack/IFile.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace ILRepacking
 {
-    public interface IFile
+    internal interface IFile
     {
         bool Exists(string path);
 

--- a/ILRepack/IKVMLineIndexer.cs
+++ b/ILRepack/IKVMLineIndexer.cs
@@ -13,7 +13,7 @@ namespace ILRepacking
     /// It was inspired by IKVM (which does it for Java assemblies), and re-uses the same attributes.
     /// It then allows at runtime to display file:line information on all stacktraces, by resolving the IL offset provided.
     /// </summary>
-    public class IKVMLineIndexer
+    internal class IKVMLineIndexer
     {
         private readonly ILRepack repack;
         private bool enabled;

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -140,7 +140,7 @@ namespace ILRepacking
             }
         }
 
-        public class AssemblyDefinitionContainer
+        internal class AssemblyDefinitionContainer
         {
             public bool SymbolsRead { get; set; }
             public AssemblyDefinition Definition { get; set; }

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -60,11 +60,11 @@ namespace ILRepacking
 
         private readonly IRepackImporter _repackImporter;
 
-        internal ILRepack(RepackOptions options, ILogger logger)
+        public ILRepack(RepackOptions options)
         {
             Options = options;
-            Logger = logger;
-            _repackImporter = new RepackImporter(logger, Options, this, this, aspOffsets);
+            Logger = options.Logger;
+            _repackImporter = new RepackImporter(options.Logger, Options, this, this, aspOffsets);
         }
 
         private void ReadInputAssemblies()

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -67,11 +67,6 @@ namespace ILRepacking
             _repackImporter = new RepackImporter(logger, Options, this, this, aspOffsets);
         }
 
-        public void Merge()
-        {
-            Repack();
-        }
-
         private void ReadInputAssemblies()
         {
             MergedAssemblyFiles = Options.InputAssemblies.SelectMany(ResolveFile).Distinct().ToList();

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -94,7 +94,7 @@ namespace ILRepacking
 
         private AssemblyDefinitionContainer ReadInputAssembly(string assembly, bool isPrimary)
         {
-            Logger.INFO("Adding assembly for merge: " + assembly);
+            Logger.Info("Adding assembly for merge: " + assembly);
             try
             {
                 ReaderParameters rp = new ReaderParameters(ReadingMode.Immediate) { AssemblyResolver = Options.GlobalAssemblyResolver };
@@ -115,7 +115,7 @@ namespace ILRepacking
                     {
                         rp.ReadSymbols = false;
                         mergeAsm = AssemblyDefinition.ReadAssembly(assembly, rp);
-                        Logger.INFO("Failed to load debug information for " + assembly);
+                        Logger.Info("Failed to load debug information for " + assembly);
                     }
                     else
                     {
@@ -135,7 +135,7 @@ namespace ILRepacking
             }
             catch
             {
-                Logger.ERROR("Failed to load assembly " + assembly);
+                Logger.Error("Failed to load assembly " + assembly);
                 throw;
             }
         }
@@ -290,17 +290,17 @@ namespace ILRepacking
             var outputDir = Path.GetDirectoryName(Options.OutputFile);
             if (!string.IsNullOrEmpty(outputDir) && !Directory.Exists(outputDir))
             {
-                Logger.INFO("Output directory does not exist. Creating output directory: " + outputDir);
+                Logger.Info("Output directory does not exist. Creating output directory: " + outputDir);
                 Directory.CreateDirectory(outputDir);
             }
             TargetAssemblyDefinition.Write(Options.OutputFile, parameters);
-            Logger.INFO("Writing output assembly to disk");
+            Logger.Info("Writing output assembly to disk");
             // If this is an executable and we are on linux/osx we should copy file permissions from
             // the primary assembly
             if (Environment.OSVersion.Platform == PlatformID.MacOSX || Environment.OSVersion.Platform == PlatformID.Unix)
             {
                 Stat stat;
-                Logger.INFO("Copying permissions from " + PrimaryAssemblyFile);
+                Logger.Info("Copying permissions from " + PrimaryAssemblyFile);
                 Syscall.stat(PrimaryAssemblyFile, out stat);
                 Syscall.chmod(Options.OutputFile, stat.st_mode);
             }
@@ -320,7 +320,7 @@ namespace ILRepacking
             foreach (var a in asm2.MainModule.AssemblyReferences.Where(x => MergedAssemblies.Any(y => Options.KeepOtherVersionReferences ? x.FullName == y.FullName : x.Name == y.Name.Name)))
             {
                 // failed
-                Logger.ERROR("Merged assembly still references " + a.FullName);
+                Logger.Error("Merged assembly still references " + a.FullName);
                 failed = true;
             }
             if (failed)
@@ -364,13 +364,13 @@ namespace ILRepacking
                 }
                 else if (!isVersionInfoRes(parents, exist))
                 {
-                    Logger.WARN(string.Format("Duplicate Win32 resource with id={0}, parents=[{1}], name={2} in assembly {3}, ignoring", entry.Id, string.Join(",", parents.Select(p => p.Name ?? p.Id.ToString()).ToArray()), entry.Name, ass.Name));
+                    Logger.Warn(string.Format("Duplicate Win32 resource with id={0}, parents=[{1}], name={2} in assembly {3}, ignoring", entry.Id, string.Join(",", parents.Select(p => p.Name ?? p.Id.ToString()).ToArray()), entry.Name, ass.Name));
                 }
                 return;
             }
             if (exist.Data != null || entry.Data != null)
             {
-                Logger.WARN("Inconsistent Win32 resources, ignoring");
+                Logger.Warn("Inconsistent Win32 resources, ignoring");
                 return;
             }
             parents.Add(exist);

--- a/ILRepack/ILogger.cs
+++ b/ILRepack/ILogger.cs
@@ -6,14 +6,10 @@ namespace ILRepacking
         bool ShouldLogVerbose { get; set; }
 
         void Log(object str);
-
-        void ERROR(string msg);
-
-        void WARN(string msg);
-
-        void INFO(string msg);
-
-        void VERBOSE(string msg);
+        void Error(string msg);
+        void Warn(string msg);
+        void Info(string msg);
+        void Verbose(string msg);
 
         void DuplicateIgnored(string ignoredType, object ignoredObject);
     }

--- a/ILRepack/IRepackContext.cs
+++ b/ILRepack/IRepackContext.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 
 namespace ILRepacking
 {
-    public interface IRepackContext
+    internal interface IRepackContext
     {
         List<AssemblyDefinition> MergedAssemblies { get; }
         ModuleDefinition TargetAssemblyMainModule { get; }

--- a/ILRepack/IRepackCopier.cs
+++ b/ILRepack/IRepackCopier.cs
@@ -19,7 +19,7 @@ using Mono.Collections.Generic;
 
 namespace ILRepacking
 {
-    public interface IRepackCopier
+    internal interface IRepackCopier
     {
         CustomAttribute Copy(CustomAttribute ca, IGenericParameterProvider context);
 

--- a/ILRepack/IRepackImporter.cs
+++ b/ILRepack/IRepackImporter.cs
@@ -19,7 +19,7 @@ using Mono.Collections.Generic;
 
 namespace ILRepacking
 {
-    public interface IRepackImporter
+    internal interface IRepackImporter
     {
         TypeReference Import(TypeReference reference, IGenericParameterProvider context);
 

--- a/ILRepack/LineNumberWriter.cs
+++ b/ILRepack/LineNumberWriter.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace ILRepacking
 {
     // copied from IKVM source
-    public sealed class LineNumberWriter
+    internal sealed class LineNumberWriter
     {
         private System.IO.MemoryStream stream;
         private int prevILOffset;

--- a/ILRepack/MappingHandler.cs
+++ b/ILRepack/MappingHandler.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace ILRepacking
 {
-    public class MappingHandler
+    internal class MappingHandler
     {
         struct Pair : IEquatable<Pair>
         {

--- a/ILRepack/MethodMatcher.cs
+++ b/ILRepack/MethodMatcher.cs
@@ -7,7 +7,7 @@ namespace ILRepacking
     /// Copied and modified from http://markmail.org/message/srpyljbjtaskoahk
     /// Which was copied and modified from Mono's Mono.Linker.Steps.TypeMapStep
     /// </summary>
-    public class MethodMatcher
+    internal class MethodMatcher
     {
         public static MethodDefinition MapVirtualMethod(MethodDefinition method)
         {

--- a/ILRepack/PermissionsetHelper.cs
+++ b/ILRepack/PermissionsetHelper.cs
@@ -24,7 +24,7 @@ using Mono.Collections.Generic;
 
 namespace ILRepacking
 {
-    public class PermissionsetHelper
+    internal class PermissionsetHelper
     {
         private static TypeReference GetTypeRef(string nameSpace, string name, string assemblyName, ModuleDefinition targetModule)
         {

--- a/ILRepack/PlatformFixer.cs
+++ b/ILRepack/PlatformFixer.cs
@@ -20,7 +20,7 @@ using System.IO;
 
 namespace ILRepacking
 {
-    public class PlatformFixer
+    internal class PlatformFixer
     {
         private TargetRuntime sourceRuntime;
         private TargetRuntime targetRuntime;

--- a/ILRepack/Properties/AssemblyInfo.cs
+++ b/ILRepack/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("ILRepack")]
@@ -14,8 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -25,14 +25,15 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
 
-[assembly:InternalsVisibleTo("ILRepack.Tests")]
+[assembly: InternalsVisibleTo("ILRepack.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/ILRepack/ReferenceFixator.cs
+++ b/ILRepack/ReferenceFixator.cs
@@ -223,7 +223,7 @@ namespace ILRepacking
                                     }
                                     else
                                     {
-                                        _logger.WARN("SecurityPermission with PublicKeyBlob found but target has no strong name!");
+                                        _logger.Warn("SecurityPermission with PublicKeyBlob found but target has no strong name!");
                                     }
                                 }
                             }
@@ -447,9 +447,9 @@ namespace ILRepacking
                                      ? method.ReturnType
                                      : method.Parameters.First(x => x.ParameterType.IsDefinition).ParameterType;
                 // warn about invalid merge assembly set, as this method is not gonna work fine (peverify would warn as well)
-                _logger.WARN("Method reference is used with definition return type / parameter. Indicates a likely invalid set of assemblies, consider one of the following");
-                _logger.WARN(" - Remove the assembly defining " + culprit + " from the merge");
-                _logger.WARN(" - Add assembly defining " + method + " to the merge");
+                _logger.Warn("Method reference is used with definition return type / parameter. Indicates a likely invalid set of assemblies, consider one of the following");
+                _logger.Warn(" - Remove the assembly defining " + culprit + " from the merge");
+                _logger.Warn(" - Add assembly defining " + method + " to the merge");
 
                 // one case where it'll work correctly however (but doesn't seem common):
                 // A references B

--- a/ILRepack/ReflectionHelper.cs
+++ b/ILRepack/ReflectionHelper.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace ILRepacking
 {
-    public class ReflectionHelper
+    internal class ReflectionHelper
     {
         private readonly IRepackContext _repack;
 

--- a/ILRepack/RepackAssemblyResolver.cs
+++ b/ILRepack/RepackAssemblyResolver.cs
@@ -1,9 +1,9 @@
-using System.Collections.Generic;
 using Mono.Cecil;
+using System.Collections.Generic;
 
 namespace ILRepacking
 {
-    public class RepackAssemblyResolver : DefaultAssemblyResolver
+    internal class RepackAssemblyResolver : DefaultAssemblyResolver
     {
         public void RegisterAssemblies(List<AssemblyDefinition> mergedAssemblies)
         {

--- a/ILRepack/RepackImporter.cs
+++ b/ILRepack/RepackImporter.cs
@@ -87,7 +87,7 @@ namespace ILRepacking
             }
             catch (ArgumentOutOfRangeException) // working around a bug in Cecil
             {
-                _logger.ERROR("Problem adding reference: " + reference.FullName);
+                _logger.Error("Problem adding reference: " + reference.FullName);
                 throw;
             }
         }
@@ -115,7 +115,7 @@ namespace ILRepacking
 
         public TypeDefinition Import(TypeDefinition type, Collection<TypeDefinition> col, bool internalize)
         {
-            _logger.VERBOSE("- Importing " + type);
+            _logger.Verbose("- Importing " + type);
 
             TypeDefinition nt = _repackContext.TargetAssemblyMainModule.GetType(type.FullName);
             bool justCreatedType = false;
@@ -126,25 +126,25 @@ namespace ILRepacking
             }
             else if (DuplicateTypeAllowed(type))
             {
-                _logger.INFO("Merging " + type);
+                _logger.Info("Merging " + type);
             }
             else if (!type.IsPublic || internalize)
             {
                 // rename the type previously imported.
                 // renaming the new one before import made Cecil throw an exception.
                 string other = "<" + Guid.NewGuid() + ">" + nt.Name;
-                _logger.INFO("Renaming " + nt.FullName + " into " + other);
+                _logger.Info("Renaming " + nt.FullName + " into " + other);
                 nt.Name = other;
                 nt = CreateType(type, col, internalize, null);
                 justCreatedType = true;
             }
             else if (_options.UnionMerge)
             {
-                _logger.INFO("Merging " + type);
+                _logger.Info("Merging " + type);
             }
             else
             {
-                _logger.ERROR("Duplicate type " + type);
+                _logger.Error("Duplicate type " + type);
                 throw new InvalidOperationException(
                     "Duplicate type " + type + " from " + type.Scope + ", was also present in " +
                     MappingHandler.GetScopeFullName(_repackContext.MappingHandler.GetOrigTypeScope<IMetadataScope>(nt)));
@@ -534,7 +534,7 @@ namespace ILRepacking
             var ret = _repackContext.ReflectionHelper.FindMethodDefinitionInType(nt, methodDefinition);
             if (ret == null)
             {
-                _logger.WARN("Method '" + methodDefinition.FullName + "' not found in merged type '" + nt.FullName + "'");
+                _logger.Warn("Method '" + methodDefinition.FullName + "' not found in merged type '" + nt.FullName + "'");
             }
             return ret;
         }

--- a/ILRepack/RepackLogger.cs
+++ b/ILRepack/RepackLogger.cs
@@ -35,22 +35,22 @@ namespace ILRepacking
             writer = null;
         }
 
-        public void ERROR(string msg)
+        public void Error(string msg)
         {
             Log("ERROR: " + msg);
         }
 
-        public void WARN(string msg)
+        public void Warn(string msg)
         {
             Log("WARN: " + msg);
         }
 
-        public void INFO(string msg)
+        public void Info(string msg)
         {
             Log("INFO: " + msg);
         }
 
-        public void VERBOSE(string msg)
+        public void Verbose(string msg)
         {
             if (ShouldLogVerbose)
                 Log("INFO: " + msg);

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -97,7 +97,7 @@ namespace ILRepacking
             TargetPlatformDirectory = targetPlatformDirectory;
         }
 
-        public void AllowDuplicateType(string typeName)
+        private void AllowDuplicateType(string typeName)
         {
             if (typeName.EndsWith(".*"))
             {
@@ -121,12 +121,9 @@ namespace ILRepacking
             this.file = file;
         }
 
-        public bool ShouldShowUsage()
-        {
-            return cmd.Modifier("?") | cmd.Modifier("help") | cmd.Modifier("h") | cmd.HasNoOptions;
-        }
+        internal bool ShouldShowUsage => cmd.Modifier("?") | cmd.Modifier("help") | cmd.Modifier("h") | cmd.HasNoOptions;
 
-        public void Parse()
+        internal void Parse()
         {
             AllowDuplicateResources = cmd.Modifier("allowduplicateresources");
             foreach (string dupType in cmd.Options("allowdup"))
@@ -245,11 +242,10 @@ namespace ILRepacking
             }
         }
 
-
         /// <summary>
         /// Parse contents of properties: central point for checking (set on assembly or through command-line).
         /// </summary>
-        public void ParseProperties()
+        internal void ParseProperties()
         {
             if (string.IsNullOrEmpty(OutputFile))
             {
@@ -274,6 +270,5 @@ namespace ILRepacking
                     excludeInternalizeMatches.Add(new Regex(line));
             }
         }
-
     }
 }

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -9,7 +9,7 @@ namespace ILRepacking
 {
     public class RepackOptions
     {
-        public class InvalidTargetKindException : Exception
+        internal class InvalidTargetKindException : Exception
         {
             public InvalidTargetKindException(string message) : base(message)
             {

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -71,7 +71,7 @@ namespace ILRepacking
         private readonly Hashtable allowedDuplicateTypes = new Hashtable();
         private readonly List<string> allowedDuplicateNameSpaces = new List<string>();
         private readonly ICommandLine cmd;
-        private readonly ILogger logger;
+        public ILogger Logger { get; private set; }
         private readonly IFile file;
         private List<Regex> excludeInternalizeMatches;
 
@@ -116,8 +116,8 @@ namespace ILRepacking
 
         internal RepackOptions(ICommandLine commandLine, ILogger logger, IFile file)
         {
-            this.cmd = commandLine;
-            this.logger = logger;
+            cmd = commandLine;
+            Logger = logger;
             this.file = file;
         }
 
@@ -215,11 +215,11 @@ namespace ILRepacking
             LineIndexation = cmd.Modifier("index");
 
             if (string.IsNullOrEmpty(KeyFile) && DelaySign)
-                logger.Warn("Option 'delaysign' is only valid with 'keyfile'.");
+                Logger.Warn("Option 'delaysign' is only valid with 'keyfile'.");
             if (AllowMultipleAssemblyLevelAttributes && !CopyAttributes)
-                logger.Warn("Option 'allowMultiple' is only valid with 'copyattrs'.");
+                Logger.Warn("Option 'allowMultiple' is only valid with 'copyattrs'.");
             if (!string.IsNullOrEmpty(AttributeFile) && (CopyAttributes))
-                logger.Warn("Option 'attr' can not be used with 'copyattrs'.");
+                Logger.Warn("Option 'attr' can not be used with 'copyattrs'.");
 
             // everything that doesn't start with a '/' must be a file to merge (verify when loading the files)
             InputAssemblies = cmd.OtherAguments;

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -53,10 +53,8 @@ namespace ILRepacking
         public bool NoRepackRes { get; set; }
         public bool KeepOtherVersionReferences { get; set; }
         public bool LineIndexation { get; set; }
-        public RepackAssemblyResolver GlobalAssemblyResolver
-        {
-            get { return globalAssemblyResolver; }
-        }
+        internal RepackAssemblyResolver GlobalAssemblyResolver { get; private set; } = new RepackAssemblyResolver();
+
         public List<Regex> ExcludeInternalizeMatches
         {
             get { return excludeInternalizeMatches; }
@@ -75,7 +73,6 @@ namespace ILRepacking
         private readonly ICommandLine cmd;
         private readonly ILogger logger;
         private readonly IFile file;
-        private readonly RepackAssemblyResolver globalAssemblyResolver = new RepackAssemblyResolver();
         private List<Regex> excludeInternalizeMatches;
 
         public void SetSearchDirectories(IEnumerable<string> dirs)
@@ -90,7 +87,7 @@ namespace ILRepacking
             }
             foreach (var dir in dirs)
             {
-                globalAssemblyResolver.AddSearchDirectory(dir);
+                GlobalAssemblyResolver.AddSearchDirectory(dir);
             }
         }
 

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -9,10 +9,10 @@ namespace ILRepacking
 {
     public class RepackOptions
     {
-        public class InvalidTargetKindException : Exception 
+        public class InvalidTargetKindException : Exception
         {
-            public InvalidTargetKindException(string message) : base(message) 
-            { 
+            public InvalidTargetKindException(string message) : base(message)
+            {
             }
         }
 
@@ -53,9 +53,9 @@ namespace ILRepacking
         public bool NoRepackRes { get; set; }
         public bool KeepOtherVersionReferences { get; set; }
         public bool LineIndexation { get; set; }
-        public RepackAssemblyResolver GlobalAssemblyResolver 
-        { 
-            get { return globalAssemblyResolver; } 
+        public RepackAssemblyResolver GlobalAssemblyResolver
+        {
+            get { return globalAssemblyResolver; }
         }
         public List<Regex> ExcludeInternalizeMatches
         {
@@ -69,7 +69,7 @@ namespace ILRepacking
         {
             get { return allowedDuplicateNameSpaces; }
         }
-        
+
         private readonly Hashtable allowedDuplicateTypes = new Hashtable();
         private readonly List<string> allowedDuplicateNameSpaces = new List<string>();
         private readonly ICommandLine cmd;
@@ -112,7 +112,12 @@ namespace ILRepacking
             }
         }
 
-        public RepackOptions(ICommandLine commandLine, ILogger logger, IFile file)
+        public RepackOptions(CommandLine commandLine, ILogger logger)
+            : this(commandLine, logger, new FileWrapper())
+        {
+        }
+
+        internal RepackOptions(ICommandLine commandLine, ILogger logger, IFile file)
         {
             this.cmd = commandLine;
             this.logger = logger;
@@ -207,7 +212,7 @@ namespace ILRepacking
             KeepOtherVersionReferences = cmd.Modifier("keepotherversionreferences");
 
             SetSearchDirectories(cmd.Options("lib"));
-            
+
             // private cmdline-Options:
             LogVerbose = cmd.Modifier("verbose");
             LineIndexation = cmd.Modifier("index");

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -215,11 +215,11 @@ namespace ILRepacking
             LineIndexation = cmd.Modifier("index");
 
             if (string.IsNullOrEmpty(KeyFile) && DelaySign)
-                logger.WARN("Option 'delaysign' is only valid with 'keyfile'.");
+                logger.Warn("Option 'delaysign' is only valid with 'keyfile'.");
             if (AllowMultipleAssemblyLevelAttributes && !CopyAttributes)
-                logger.WARN("Option 'allowMultiple' is only valid with 'copyattrs'.");
+                logger.Warn("Option 'allowMultiple' is only valid with 'copyattrs'.");
             if (!string.IsNullOrEmpty(AttributeFile) && (CopyAttributes))
-                logger.WARN("Option 'attr' can not be used with 'copyattrs'.");
+                logger.Warn("Option 'attr' can not be used with 'copyattrs'.");
 
             // everything that doesn't start with a '/' must be a file to merge (verify when loading the files)
             InputAssemblies = cmd.OtherAguments;

--- a/ILRepack/ResReader.cs
+++ b/ILRepack/ResReader.cs
@@ -157,7 +157,7 @@ namespace ILRepacking
         StartOfUserTypes = 64,
     }
 
-    public class Res
+    internal class Res
     {
         public readonly String name;
         public readonly String type;
@@ -185,7 +185,7 @@ namespace ILRepacking
         }
     }
 
-    public sealed class ResReader : IEnumerable<Res>, IDisposable
+    internal sealed class ResReader : IEnumerable<Res>, IDisposable
     {
         private BinaryReader _store;    // backing store we're reading from.
         private readonly long _nameSectionOffset;  // Offset to name section of file.

--- a/ILRepack/SerReader.cs
+++ b/ILRepack/SerReader.cs
@@ -44,7 +44,7 @@ namespace ILRepacking
      * Home-made Serialized data parser, that only parses records to map merged type references
      * Other than that, it just streams the data from the input to the output unchanged.
      */
-    public class SerReader
+    internal class SerReader
     {
         private readonly IRepackContext _repackContext;
 
@@ -243,19 +243,19 @@ namespace ILRepacking
         }
     }
 
-    public class BinaryLibrary
+    internal class BinaryLibrary
     {
         public int LibraryID;
         public string Name;
     }
 
-    public interface SerialObject
+    internal interface SerialObject
     {
         int ObjectID { get; set; }
         long? ParentObjectID { get; set; }
     }
 
-    public interface TypeHoldingThing
+    internal interface TypeHoldingThing
     {
         SerialObject RelevantObject { get; set; }
         BinaryTypeEnumeration? BinaryType { get; set; }
@@ -269,7 +269,7 @@ namespace ILRepacking
         object ValueRefID { get; set; }
     }
 
-    public class ObjectWithId : SerialObject
+    internal class ObjectWithId : SerialObject
     {
         public int ObjectID { get; set; }
         public long? ParentObjectID { get; set; }
@@ -281,7 +281,7 @@ namespace ILRepacking
         }
     }
 
-    public class ClassInfo : ObjectWithId
+    internal class ClassInfo : ObjectWithId
     {
         internal ClassInfo() { }
 
@@ -343,7 +343,7 @@ namespace ILRepacking
         public int ReferenceCount;
     }
 
-    public class MemberInfo : TypeHoldingThing, ValueHoldingThing
+    internal class MemberInfo : TypeHoldingThing, ValueHoldingThing
     {
         public string Name;
         public SerialObject RelevantObject { get; set; }
@@ -354,13 +354,13 @@ namespace ILRepacking
         public object ValueRefID { get; set; }
     }
 
-    public class ClassTypeInfo
+    internal class ClassTypeInfo
     {
         public string TypeName;
         public int? LibraryID;
     }
 
-    public class ObjectString : ObjectWithId
+    internal class ObjectString : ObjectWithId
     {
         public string String;
 
@@ -377,7 +377,7 @@ namespace ILRepacking
         }
     }
 
-    public class BinaryArray : ObjectWithId, TypeHoldingThing
+    internal class BinaryArray : ObjectWithId, TypeHoldingThing
     {
         internal BinaryArray() { }
 
@@ -580,7 +580,7 @@ namespace ILRepacking
     }
 
 
-    public enum RecordTypeEnumeration
+    internal enum RecordTypeEnumeration
     {
         SerializedStreamHeader = 0,
         ClassWithID = 1,                    //Object,
@@ -607,7 +607,7 @@ namespace ILRepacking
         MethodReturn = 22
     }
 
-    public enum BinaryTypeEnumeration
+    internal enum BinaryTypeEnumeration
     {
         Primitive = 0,
         String = 1,
@@ -619,7 +619,7 @@ namespace ILRepacking
         PrimitiveArray = 7
     }
 
-    public enum PrimitiveTypeEnumeration
+    internal enum PrimitiveTypeEnumeration
     {
         Boolean = 1,
         Byte = 2,
@@ -641,7 +641,7 @@ namespace ILRepacking
         String = 18
     }
 
-    public enum BinaryArrayTypeEnumeration
+    internal enum BinaryArrayTypeEnumeration
     {
         Single = 0,
         Jagged = 1,

--- a/ILRepack/Steps/AttributesRepackStep.cs
+++ b/ILRepack/Steps/AttributesRepackStep.cs
@@ -99,7 +99,7 @@ namespace ILRepacking.Steps
             {
                 if (RemoveAttributes(type, null))
                 {
-                    _logger.WARN("[" + type + "] attribute wasn't merged because of inconsistency across merged assemblies");
+                    _logger.Warn("[" + type + "] attribute wasn't merged because of inconsistency across merged assemblies");
                 }
             }
         }
@@ -109,7 +109,7 @@ namespace ILRepacking.Steps
             bool ret = false;
             foreach (var ass in _repackContext.MergedAssemblies)
             {
-                for (int i = 0; i < ass.CustomAttributes.Count; )
+                for (int i = 0; i < ass.CustomAttributes.Count;)
                 {
                     if (ass.CustomAttributes[i].AttributeType.FullName == attrTypeName && (predicate == null || predicate(ass.CustomAttributes[i])))
                     {

--- a/ILRepack/Steps/ReferencesFixStep.cs
+++ b/ILRepack/Steps/ReferencesFixStep.cs
@@ -39,7 +39,7 @@ namespace ILRepacking.Steps
 
         public void Perform()
         {
-            _logger.INFO("Fixing references");
+            _logger.Info("Fixing references");
 
             var fixator = new ReferenceFixator(_logger, _repackContext);
             if (_repackContext.PrimaryAssemblyMainModule.EntryPoint != null)

--- a/ILRepack/Steps/ReferencesRepackStep.cs
+++ b/ILRepack/Steps/ReferencesRepackStep.cs
@@ -32,7 +32,7 @@ namespace ILRepacking.Steps
 
         public void Perform()
         {
-            _logger.INFO("Processing references");
+            _logger.Info("Processing references");
 
             // Add all AssemblyReferences to merged assembly (probably not necessary)
             var targetAssemblyMainModule = _repackContext.TargetAssemblyMainModule;
@@ -47,7 +47,7 @@ namespace ILRepacking.Steps
                     // TODO: fix .NET runtime references?
                     // - to target a specific runtime version or
                     // - to target a single version if merged assemblies target different versions
-                    _logger.VERBOSE("- add reference " + z);
+                    _logger.Verbose("- add reference " + z);
                     AssemblyNameReference fixedRef = _repackContext.PlatformFixer.FixPlatformVersion(z);
                     targetAssemblyMainModule.AssemblyReferences.Add(fixedRef);
                 }

--- a/ILRepack/Steps/ResourceProcessing/BamlGenerator.cs
+++ b/ILRepack/Steps/ResourceProcessing/BamlGenerator.cs
@@ -98,7 +98,7 @@ namespace ILRepacking.Steps.ResourceProcessing
                 if (document.FindIndex(IsResourceDictionaryElementStart) == -1)
                 {
                     //TODO: throw? (Let's hope people read the logs ^_^)
-                    _logger.ERROR(string.Format(
+                    _logger.Error(string.Format(
                         "Existing 'Themes/generic.xaml' in {0} is *not* a ResourceDictionary. " +
                         "This will prevent proper WPF application merging.", _mainAssemblyName));
                     return;
@@ -107,7 +107,7 @@ namespace ILRepacking.Steps.ResourceProcessing
                 int attributeInfosStartIndex = document.FindLastIndex(r => r is AssemblyInfoRecord);
                 if (attributeInfosStartIndex == -1)
                 {
-                    _logger.ERROR("Invalid BAML detected. (no AssemblyInfoRecord)");
+                    _logger.Error("Invalid BAML detected. (no AssemblyInfoRecord)");
                     return;
                 }
 
@@ -118,7 +118,7 @@ namespace ILRepacking.Steps.ResourceProcessing
                 int defferableRecordIndex = document.FindIndex(r => r is DeferableContentStartRecord);
                 if (attributeInfosStartIndex == -1)
                 {
-                    _logger.ERROR("Invalid BAML detected. (No DeferableContentStartRecord)");
+                    _logger.Error("Invalid BAML detected. (No DeferableContentStartRecord)");
                 }
 
                 document.InsertRange(defferableRecordIndex, GetDictionariesList(importedFiles));

--- a/ILRepack/Steps/ResourceProcessing/BamlStreamCollector.cs
+++ b/ILRepack/Steps/ResourceProcessing/BamlStreamCollector.cs
@@ -98,7 +98,7 @@ namespace ILRepacking.Steps.ResourceProcessing
         private void PatchExistingGenericThemesXaml(
             ResourceWriter resourceWriter, BamlDocument bamlDocument, IEnumerable<string> genericThemeResources)
         {
-            _logger.INFO("Patching existing themes/generic.xaml");
+            _logger.Info("Patching existing themes/generic.xaml");
 
             _bamlGenerator.AddMergedDictionaries(bamlDocument, genericThemeResources);
 
@@ -109,7 +109,7 @@ namespace ILRepacking.Steps.ResourceProcessing
         private void AddNewGenericThemesXaml(
             ResourceWriter resourceWriter, IEnumerable<string> genericThemeResources)
         {
-            _logger.INFO("Creating new themes/generic.xaml");
+            _logger.Info("Creating new themes/generic.xaml");
             var newBamlDocument = _bamlGenerator.GenerateThemesGenericXaml(genericThemeResources);
 
             resourceWriter.AddResourceData(

--- a/ILRepack/Steps/ResourcesRepackStep.cs
+++ b/ILRepack/Steps/ResourcesRepackStep.cs
@@ -45,7 +45,7 @@ namespace ILRepacking.Steps
 
         public void Perform()
         {
-            _logger.INFO("Processing resources");
+            _logger.Info("Processing resources");
             // merge resources
             IEnumerable<string> repackList = new List<string>();
             Dictionary<string, List<int>> ikvmExportsLists = new Dictionary<string, List<int>>();
@@ -90,17 +90,17 @@ namespace ILRepacking.Steps
                         if (!_options.AllowDuplicateResources && _targetAssemblyMainModule.Resources.Any(x => x.Name == resource.Name))
                         {
                             // Not much we can do about 'ikvm__META-INF!MANIFEST.MF'
-                            _logger.WARN("Ignoring duplicate resource " + resource.Name);
+                            _logger.Warn("Ignoring duplicate resource " + resource.Name);
                         }
                         else
                         {
-                            _logger.VERBOSE("- Importing " + resource.Name);
+                            _logger.Verbose("- Importing " + resource.Name);
                             var newResource = resource;
                             switch (resource.ResourceType)
                             {
                                 case ResourceType.AssemblyLinked:
                                     // TODO
-                                    _logger.WARN("AssemblyLinkedResource reference may need to be fixed (to link to newly created assembly)" + resource.Name);
+                                    _logger.Warn("AssemblyLinkedResource reference may need to be fixed (to link to newly created assembly)" + resource.Name);
                                     break;
                                 case ResourceType.Linked:
                                     // TODO ? (or not)
@@ -226,7 +226,7 @@ namespace ILRepacking.Steps
             {
                 foreach (var res in rr)
                 {
-                    _logger.VERBOSE(string.Format("- Resource '{0}' (type: {1})", res.name, res.type));
+                    _logger.Verbose(string.Format("- Resource '{0}' (type: {1})", res.name, res.type));
 
                     foreach (var processor in resourcePrcessors)
                     {

--- a/ILRepack/Steps/ResourcesRepackStep.cs
+++ b/ILRepack/Steps/ResourcesRepackStep.cs
@@ -226,8 +226,6 @@ namespace ILRepacking.Steps
             {
                 foreach (var res in rr)
                 {
-                    _logger.Verbose(string.Format("- Resource '{0}' (type: {1})", res.name, res.type));
-
                     foreach (var processor in resourcePrcessors)
                     {
                         if (processor.Process(containingAssembly, res, rr, rw))

--- a/ILRepack/Steps/TypesRepackStep.cs
+++ b/ILRepack/Steps/TypesRepackStep.cs
@@ -47,19 +47,19 @@ namespace ILRepacking.Steps
 
         private void RepackTypes()
         {
-            _logger.INFO("Processing types");
+            _logger.Info("Processing types");
             // merge types, this differs between 'primary' and 'other' assemblies regarding internalizing
 
             foreach (var r in _repackContext.PrimaryAssemblyDefinition.Modules.SelectMany(x => x.Types))
             {
-                _logger.VERBOSE("- Importing " + r);
+                _logger.Verbose("- Importing " + r);
                 _repackImporter.Import(r, _repackContext.TargetAssemblyMainModule.Types, false);
             }
             foreach (var m in _repackContext.OtherAssemblies.SelectMany(x => x.Modules))
             {
                 foreach (var r in m.Types)
                 {
-                    _logger.VERBOSE("- Importing " + r);
+                    _logger.Verbose("- Importing " + r);
                     _repackImporter.Import(r, _repackContext.TargetAssemblyMainModule.Types, ShouldInternalize(r.FullName));
                 }
             }
@@ -68,7 +68,7 @@ namespace ILRepacking.Steps
         private void RepackExportedTypes()
         {
             var targetAssemblyMainModule = _repackContext.TargetAssemblyMainModule;
-            _logger.INFO("Processing types");
+            _logger.Info("Processing types");
             foreach (var m in _repackContext.MergedAssemblies.SelectMany(x => x.Modules))
             {
                 foreach (var r in m.ExportedTypes)
@@ -78,7 +78,7 @@ namespace ILRepacking.Steps
             }
             foreach (var r in _repackContext.PrimaryAssemblyDefinition.Modules.SelectMany(x => x.ExportedTypes))
             {
-                _logger.VERBOSE("- Importing Exported Type" + r);
+                _logger.Verbose("- Importing Exported Type" + r);
                 _repackImporter.Import(r, targetAssemblyMainModule.ExportedTypes, targetAssemblyMainModule);
             }
             foreach (var m in _repackContext.OtherAssemblies.SelectMany(x => x.Modules))
@@ -87,12 +87,12 @@ namespace ILRepacking.Steps
                 {
                     if (!ShouldInternalize(r.FullName))
                     {
-                        _logger.VERBOSE("- Importing Exported Type " + r);
+                        _logger.Verbose("- Importing Exported Type " + r);
                         _repackImporter.Import(r, targetAssemblyMainModule.ExportedTypes, targetAssemblyMainModule);
                     }
                     else
                     {
-                        _logger.VERBOSE("- Skipping Exported Type " + r);
+                        _logger.Verbose("- Skipping Exported Type " + r);
                     }
                 }
             }

--- a/ILRepack/Steps/XamlResourcePathPatcherStep.cs
+++ b/ILRepack/Steps/XamlResourcePathPatcherStep.cs
@@ -36,7 +36,7 @@ namespace ILRepacking.Steps
         {
             var types = _repackContext.TargetAssemblyDefinition.Modules.SelectMany(m => m.Types);
 
-            _logger.VERBOSE("Processing XAML resource paths ...");
+            _logger.Verbose("Processing XAML resource paths ...");
             foreach (var type in types)
             {
                 PatchInitializeComponentMethod(type);
@@ -58,7 +58,7 @@ namespace ILRepacking.Steps
 
             if (endInitMethod == null)
             {
-                _logger.WARN("Could not find a proper 'EndInit' method for Xceed.Wpf.Toolkit to patch!");
+                _logger.Warn("Could not find a proper 'EndInit' method for Xceed.Wpf.Toolkit to patch!");
                 return;
             }
 
@@ -73,7 +73,7 @@ namespace ILRepacking.Steps
             if (initializeMethod == null || !initializeMethod.HasBody)
                 return;
 
-            _logger.VERBOSE(" - Patching type " + type.FullName);
+            _logger.Verbose(" - Patching type " + type.FullName);
             PatchMethod(initializeMethod);
         }
 
@@ -112,8 +112,8 @@ namespace ILRepacking.Steps
         }
 
         internal static string PatchPath(
-            string path, 
-            AssemblyDefinition primaryAssembly, 
+            string path,
+            AssemblyDefinition primaryAssembly,
             AssemblyDefinition sourceAssembly,
             List<AssemblyDefinition> otherAssemblies)
         {


### PR DESCRIPTION
Since 2.0.0 release is imminent I took the liberty to cleanup the API a bit and improve it.

Another notable thing is that I started using C# 6 Expression bodied members feature for properties :P Let's see if this properly compiles on mono.

This shouldn't be merged yet - I still have to cleanup the ILRepack class a bit.