### PR TITLE
Throw exception when invalid options are provided

### DIFF
--- a/ILRepack.IntegrationTests/WPFScenarios.cs
+++ b/ILRepack.IntegrationTests/WPFScenarios.cs
@@ -6,7 +6,7 @@ using System.IO;
 namespace ILRepack.IntegrationTests
 {
     [TestFixture]
-    [Platform(Include = "windows")]
+    [Platform(Include = "win")]
     public class WPFScenarios
     {
         private const int ScenarioProcessWaitTimeInMs = 10000;

--- a/ILRepack.Tests/NuGet/TestHelpers.cs
+++ b/ILRepack.Tests/NuGet/TestHelpers.cs
@@ -33,14 +33,14 @@ namespace ILRepack.Tests.NuGet
 
         public static void DoRepackForCmd(IEnumerable<string> args)
         {
-            var repack = new ILRepacking.ILRepack(GetOptionsForCmd(args));
+            var repack = new ILRepacking.ILRepack(GetOptionsForCmd(args), logger);
             repack.Repack();
         }
 
         public static RepackOptions GetOptionsForCmd(IEnumerable<string> args)
         {
             ICommandLine commandLine = new CommandLine(args.Concat(new[] { "/log" }).ToArray());
-            RepackOptions options = new RepackOptions(commandLine, TestHelpers.logger, new FileWrapper());
+            RepackOptions options = new RepackOptions(commandLine, new FileWrapper());
             options.Parse();
             return options;
         }

--- a/ILRepack.Tests/RepackOptionsTests.cs
+++ b/ILRepack.Tests/RepackOptionsTests.cs
@@ -21,7 +21,7 @@ namespace ILRepack.Tests
             repackLogger = new Mock<ILogger>();
             commandLine = new Mock<ICommandLine>();
             file = new Mock<IFile>();
-            options = new RepackOptions(commandLine.Object, repackLogger.Object, file.Object);
+            options = new RepackOptions(commandLine.Object, file.Object);
         }
 
         [Test]
@@ -209,29 +209,31 @@ namespace ILRepack.Tests
         }
 
         [Test]
-        public void WithOptionKeyFileNotSet_WithDelaySign__Parse__Warn()
+        public void WithOptionKeyFileNotSet_WithDelaySign__Parse__ThrowsInvalidOperationException()
         {
             commandLine.Setup(cmd => cmd.Modifier("delaysign")).Returns(true);
-            options.Parse();
-            repackLogger.Verify(logger => logger.Warn(It.IsAny<string>()));
+
+            Assert.Throws<InvalidOperationException>(() => options.Parse());
         }
 
         [Test]
-        public void WithAllowMultipleAssign_WithNoCopyAttributes__Parse__Warn()
+        public void WithAllowMultipleAssign_WithNoCopyAttributes__Parse__ThrowsInvalidOperationException()
         {
             commandLine.Setup(cmd => cmd.Modifier("allowmultiple")).Returns(true);
-            options.Parse();
-            repackLogger.Verify(logger => logger.Warn(It.IsAny<string>()));
+
+            Assert.Throws<InvalidOperationException>(() => options.Parse());
         }
 
         [Test]
-        public void WithAttributeFile_WithCopyAttributes__Parse__Warn()
+        public void WithAttributeFile_WithCopyAttributes__Parse__ThrowsInvalidOperationException()
         {
             const string attributeFile = "filename";
             commandLine.Setup(cmd => cmd.Option("attr")).Returns(attributeFile);
             commandLine.Setup(cmd => cmd.Modifier("copyattrs")).Returns(true);
+
             options.Parse();
-            repackLogger.Verify(logger => logger.Warn(It.IsAny<string>()));
+
+            Assert.Throws<InvalidOperationException>(() => options.Parse());
         }
 
         [Test]
@@ -284,6 +286,5 @@ namespace ILRepack.Tests
             var pattern = options.ExcludeInternalizeMatches.First();
             Assert.IsTrue(pattern.IsMatch(keyFileLines.First()));
         }
-
     }
 }

--- a/ILRepack/Application.cs
+++ b/ILRepack/Application.cs
@@ -7,10 +7,8 @@ namespace ILRepacking
         [STAThread]
         static int Main(string[] args)
         {
-            ICommandLine commandLine = new CommandLine(args);
             RepackLogger logger = new RepackLogger();
-            IFile file = new FileWrapper();
-            RepackOptions options = new RepackOptions(commandLine, logger, file);
+            RepackOptions options = new RepackOptions(args);
             int returnCode = -1;
             try
             {
@@ -28,7 +26,7 @@ namespace ILRepacking
                     options.Log = true;
                 }
 
-                ILRepack repack = new ILRepack(options);
+                ILRepack repack = new ILRepack(options, logger);
                 repack.Repack();
                 returnCode = 0;
             }

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -61,11 +61,11 @@ namespace ILRepacking
 
         private readonly IRepackImporter _repackImporter;
 
-        public ILRepack(RepackOptions options)
+        public ILRepack(RepackOptions options, ILogger logger)
         {
             Options = options;
-            Logger = options.Logger;
-            _repackImporter = new RepackImporter(options.Logger, Options, this, this, aspOffsets);
+            Logger = logger;
+            _repackImporter = new RepackImporter(Logger, Options, this, this, aspOffsets);
         }
 
         private void ReadInputAssemblies()

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -71,7 +71,6 @@ namespace ILRepacking
         private readonly Hashtable allowedDuplicateTypes = new Hashtable();
         private readonly List<string> allowedDuplicateNameSpaces = new List<string>();
         private readonly ICommandLine cmd;
-        public ILogger Logger { get; private set; }
         private readonly IFile file;
         private List<Regex> excludeInternalizeMatches;
 
@@ -87,15 +86,19 @@ namespace ILRepacking
             }
         }
 
-        public RepackOptions(CommandLine commandLine, ILogger logger)
-            : this(commandLine, logger, new FileWrapper())
+        public RepackOptions(IEnumerable<string> ilRepackArguments)
+            : this(new CommandLine(ilRepackArguments))
         {
         }
 
-        internal RepackOptions(ICommandLine commandLine, ILogger logger, IFile file)
+        public RepackOptions(CommandLine commandLine)
+            : this(commandLine, new FileWrapper())
+        {
+        }
+
+        internal RepackOptions(ICommandLine commandLine, IFile file)
         {
             cmd = commandLine;
-            Logger = logger;
             this.file = file;
         }
 
@@ -184,11 +187,13 @@ namespace ILRepacking
             LineIndexation = cmd.Modifier("index");
 
             if (string.IsNullOrEmpty(KeyFile) && DelaySign)
-                Logger.Warn("Option 'delaysign' is only valid with 'keyfile'.");
+                throw new InvalidOperationException("Option 'delaysign' is only valid with 'keyfile'.");
+
             if (AllowMultipleAssemblyLevelAttributes && !CopyAttributes)
-                Logger.Warn("Option 'allowMultiple' is only valid with 'copyattrs'.");
+                throw new InvalidOperationException("Option 'allowMultiple' is only valid with 'copyattrs'.");
+
             if (!string.IsNullOrEmpty(AttributeFile) && (CopyAttributes))
-                Logger.Warn("Option 'attr' can not be used with 'copyattrs'.");
+                throw new InvalidOperationException("Option 'attr' can not be used with 'copyattrs'.");
 
             // everything that doesn't start with a '/' must be a file to merge (verify when loading the files)
             InputAssemblies = cmd.OtherAguments;


### PR DESCRIPTION
This will allow us to get rid of the Logger in the
Options.

Also, simplify a bit the RepackOptions constructor

Missed the 2.0 release :P