### PR TITLE
Added public modifier for RepackLogger

### DIFF
--- a/ILRepack/RepackLogger.cs
+++ b/ILRepack/RepackLogger.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace ILRepacking
 {
-    class RepackLogger : ILogger
+    public class RepackLogger : ILogger
     {
         private string outputFile;
         private StreamWriter writer;


### PR DESCRIPTION
When using ILRepack as a lib a logger needs to be provided.
It can be useful to reuse this one.