### PR TITLE
Verbose print types during `fixing references` step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 IL Repack changelog
 ====================
 
+2.0.3
+-------
+* Types fixed during the 'Fixing references' phase are printed in verbose mode.
+
 2.0.0
 -------
 

--- a/ILRepack/RepackLogger.cs
+++ b/ILRepack/RepackLogger.cs
@@ -3,10 +3,10 @@ using System.IO;
 
 namespace ILRepacking
 {
-    class RepackLogger : ILogger
+    internal class RepackLogger : ILogger
     {
-        private string outputFile;
-        private StreamWriter writer;
+        private string _outputFile;
+        private StreamWriter _writer;
 
         public bool ShouldLogVerbose { get; set; }
 
@@ -14,46 +14,45 @@ namespace ILRepacking
         {
             string logStr = str.ToString();
             Console.WriteLine(logStr);
-            if (writer != null)
-                writer.WriteLine(logStr);
+            _writer?.WriteLine(logStr);
         }
 
         public bool Open(string file)
         {
             if (string.IsNullOrEmpty(file))
                 return false;
-            outputFile = file;
-            writer = new StreamWriter(outputFile);
+            _outputFile = file;
+            _writer = new StreamWriter(_outputFile);
             return true;
         }
 
         public void Close()
         {
-            if (writer == null)
+            if (_writer == null)
                 return;
-            writer.Close();
-            writer = null;
+            _writer.Close();
+            _writer = null;
         }
 
         public void Error(string msg)
         {
-            Log("ERROR: " + msg);
+            Log($"ERROR: {msg}");
         }
 
         public void Warn(string msg)
         {
-            Log("WARN: " + msg);
+            Log($"WARN: {msg}");
         }
 
         public void Info(string msg)
         {
-            Log("INFO: " + msg);
+            Log($"INFO: {msg}");
         }
 
         public void Verbose(string msg)
         {
             if (ShouldLogVerbose)
-                Log("INFO: " + msg);
+                Log($"VERBOSE: {msg}");
         }
 
         public void DuplicateIgnored(string ignoredType, object ignoredObject)

--- a/ILRepack/Steps/ReferencesFixStep.cs
+++ b/ILRepack/Steps/ReferencesFixStep.cs
@@ -53,6 +53,7 @@ namespace ILRepacking.Steps
             // this step travels through all TypeRefs & replaces them by matching TypeDefs
             foreach (var r in targetAssemblyMainModule.Types)
             {
+                _logger.Verbose($"- Fixing references for type {r}");
                 fixator.FixReferences(r);
             }
             foreach (var r in targetAssemblyMainModule.Types)


### PR DESCRIPTION
This aids in debugging any breaking changes between
libraries.