### PR TITLE
Adds empty constructor to RepackOptions.

### DIFF
--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -86,6 +86,11 @@ namespace ILRepacking
             }
         }
 
+        public RepackOptions()
+            : this(new CommandLine(Enumerable.Empty<String>()))
+        {
+        }
+
         public RepackOptions(IEnumerable<string> ilRepackArguments)
             : this(new CommandLine(ilRepackArguments))
         {


### PR DESCRIPTION
This allows users to use an initializer to setup the `RepackOptions`, giving them type/name checking at compile time rather than runtime.

Example usage:
```cs
var ilRepackOptions = new RepackOptions()
{
	AllowDuplicateResources = false,
	AllowMultipleAssemblyLevelAttributes = false,
	AllowWildCards = false,
	AllowZeroPeKind = false,
	AttributeFile = null,
	CopyAttributes = false,
	DebugInfo = true,
	DelaySign = false,
	ExcludeFile = null,
	InputAssemblies = assemblyPathsToRepack.ToArray(),
	Internalize = true,
	KeepOtherVersionReferences = true,
	KeyFile = keyFilePath,
	LineIndexation = false,
	NoRepackRes = true,
	OutputFile = destinationFilePath,
	Parallel = true,
	PauseBeforeExit = false,
	SearchDirectories = new [] { sourceDirectoryPath },
	TargetKind = ILRepack.Kind.SameAsPrimaryAssembly,
	UnionMerge = false,
	Version = null,
	XmlDocumentation = false,
};
var ilRepack = new ILRepack(ilRepackOptions);
ilRepack.Repack();
```