### PR TITLE
Fixed indirect dependency xaml merging

### DIFF
--- a/ILRepack/Steps/ResourceProcessing/BamlResourcePatcher.cs
+++ b/ILRepack/Steps/ResourceProcessing/BamlResourcePatcher.cs
@@ -84,8 +84,10 @@ namespace ILRepacking.Steps.ResourceProcessing
 
         private void ProcessRecord(AssemblyInfoRecord record)
         {
+            var assemblyName = new System.Reflection.AssemblyName(record.AssemblyFullName);
+
             var assemblyDefinition = _otherAssemblies.FirstOrDefault(
-                asm => asm.Name.Name == record.AssemblyFullName || asm.Name.FullName == record.AssemblyFullName);
+                asm => asm.Name.Name == assemblyName.Name || asm.Name.FullName == record.AssemblyFullName);
 
             if (assemblyDefinition != null)
             {


### PR DESCRIPTION
When merging A & B into C, if:
- B has a reference to A in a xaml (a resource dictionary in my case)
- B references A 1.0.0.0
- C references A 2.0.0.0 & B
Then, in the final merged assembly, the reference is not replaced
because the fullname does not match.