### PR TITLE
Fixes cannot reduce access for some virtual methods

### DIFF
--- a/ILRepack/MethodMatcher.cs
+++ b/ILRepack/MethodMatcher.cs
@@ -21,11 +21,6 @@ namespace ILRepacking
             return baseMethod;
         }
 
-        public static MethodDefinition MapVirtualMethodToNearestBase(MethodDefinition method)
-        {
-            return GetBaseMethodInTypeHierarchy(method);
-        }
-
         static MethodDefinition GetBaseMethodInTypeHierarchy(MethodDefinition method)
         {
             TypeDefinition @base = GetBaseType(method.DeclaringType);

--- a/ILRepack/MethodMatcher.cs
+++ b/ILRepack/MethodMatcher.cs
@@ -9,7 +9,19 @@ namespace ILRepacking
     /// </summary>
     internal class MethodMatcher
     {
-        public static MethodDefinition MapVirtualMethod(MethodDefinition method)
+        public static MethodDefinition MapVirtualMethodToDeepestBase(MethodDefinition method)
+        {
+            MethodDefinition baseMethod = null;
+            var candidate = GetBaseMethodInTypeHierarchy(method);
+            while (candidate != null)
+            {
+                baseMethod = candidate;
+                candidate = GetBaseMethodInTypeHierarchy(baseMethod);
+            }
+            return baseMethod;
+        }
+
+        public static MethodDefinition MapVirtualMethodToNearestBase(MethodDefinition method)
         {
             return GetBaseMethodInTypeHierarchy(method);
         }

--- a/ILRepack/ReferenceFixator.cs
+++ b/ILRepack/ReferenceFixator.cs
@@ -584,7 +584,7 @@ namespace ILRepacking
             }
 
             // no explicit overrides found, check implicit overrides
-            MethodDefinition @base = MethodMatcher.MapVirtualMethod(meth);
+            MethodDefinition @base = MethodMatcher.MapVirtualMethodToDeepestBase(meth);
             if (@base != null && @base.IsVirtual)
                 Fix(@base, meth);
         }


### PR DESCRIPTION
This pull request solve the problem I had in #148 when merging Microsoft.Build assemblies.