### PR TITLE
Improve Mono build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: csharp
 script:
-  - ./gradlew -is --console plain msbuild nunit
+  - ./gradlew -is --console plain nunit repack 

--- a/ILRepack.IntegrationTests/NuGet/RepackNuGetTests.cs
+++ b/ILRepack.IntegrationTests/NuGet/RepackNuGetTests.cs
@@ -38,10 +38,11 @@ namespace ILRepack.IntegrationTests.NuGet
         }
 
         [Category("LongRunning")]
+        [Platform(Include = "win")]
         [TestCaseSource(typeof(Data), "Platforms", Category = "ComplexTests")]
         public void NupkgPlatform(Platform platform)
         {
-            var files = Observable.ToObservable(platform.Packages)
+            Observable.ToObservable(platform.Packages)
             .SelectMany(NuGetHelpers.GetNupkgAssembliesAsync)
             .Do(lib => TestHelpers.SaveAs(lib.Item2(), tempDirectory, lib.Item1))
             .Select(lib => Path.GetFileName(lib.Item1))

--- a/build.gradle
+++ b/build.gradle
@@ -55,13 +55,17 @@ task repack(dependsOn: [msbuild, nunitLongRunning]) {
 }
 
 repack << {
+    def isMono = !OperatingSystem.current().windows
+    def outputPath = msbuild.mainProject.getProjectPropertyPath('OutputPath')
+    def repackExe = new File(outputPath, 'ILRepack.exe')
+    def executable = isMono ? ['mono', repackExe] : [repackExe]
     exec {
-        workingDir = msbuild.mainProject.getProjectPropertyPath('OutputPath')
-        commandLine = [new File(workingDir, 'ILRepack.exe'), '/log', '/wildcards', '/internalize', '/ndebug', '/out:'+ext.repacked] + project.ext.repackList
+        workingDir = outputPath
+        commandLine = [*executable, '/log', '/wildcards', '/internalize', '/ndebug', '/out:'+ext.repacked] + project.ext.repackList
     }
     exec {
-        workingDir = msbuild.mainProject.getProjectPropertyPath('OutputPath')
-        commandLine = [new File(workingDir, 'ILRepack.exe'), '/log', '/wildcards', '/internalize', '/keyfile:'+file('ILRepack/ILRepack.snk'), '/out:'+ext.repackedLib, '/target:library'] + project.ext.repackList
+        workingDir = outputPath
+        commandLine = [*executable, '/log', '/wildcards', '/internalize', '/keyfile:'+file('ILRepack/ILRepack.snk'), '/out:'+ext.repackedLib, '/target:library'] + project.ext.repackList
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.internal.os.OperatingSystem
 
 plugins {
-  id 'com.ullink.msbuild' version '2.14'
+  id 'com.ullink.msbuild' version '2.15'
   id 'com.ullink.nuget' version '2.12'
   id 'com.ullink.nunit' version '1.4'
   id 'com.ullink.opencover' version '1.2'


### PR DESCRIPTION
Fixes #156

These changes allow "./gradlew repack" to succeed on Mono 4.4.0. The long running tests are disabled due to a dependency on PEVerify.