### PR TITLE
support merging interdependent xaml resources from same-named dlls

### DIFF
--- a/ILRepack/Steps/ResourceProcessing/BamlStreamCollector.cs
+++ b/ILRepack/Steps/ResourceProcessing/BamlStreamCollector.cs
@@ -119,7 +119,7 @@ namespace ILRepacking.Steps.ResourceProcessing
 
         private string GetResourceName(Res resource, AssemblyDefinition assembly)
         {
-            if (assembly == _primaryAssemblyDefinition)
+            if (assembly.Name.Name == _primaryAssemblyDefinition.Name.Name)
                 return resource.name;
 
             return string.Format("{0}/{1}", assembly.Name.Name.ToLowerInvariant(), resource.name);

--- a/ILRepack/Steps/ResourcesRepackStep.cs
+++ b/ILRepack/Steps/ResourcesRepackStep.cs
@@ -55,7 +55,7 @@ namespace ILRepacking.Steps
                 repackList = _repackContext.MergedAssemblies.Select(a => a.FullName).ToList();
             }
 
-            var bamlStreamCollector = new BamlStreamCollector(_logger, _repackContext);
+            var bamlStreamCollector = new StreamCollector(_logger, _repackContext);
             var bamlResourcePatcher = new BamlResourcePatcher(_repackContext);
 
             var primaryAssemblyProcessors =
@@ -120,10 +120,19 @@ namespace ILRepacking.Steps
 
                                         newResource = FixResxResource(assembly, er, assemblyProcessors,
                                             shouldWriteCollectedBamlStreams ? bamlStreamCollector : null);
+
+                                        if (!isPrimaryAssembly && assembly.Name.Name == _repackContext.PrimaryAssemblyDefinition.Name.Name)
+                                        {
+                                            newResource = null; // nothing to write, as all streams were collected
+                                        }
                                     }
                                     break;
                             }
-                            _targetAssemblyMainModule.Resources.Add(newResource);
+
+                            if (newResource != null)
+                            {
+                                _targetAssemblyMainModule.Resources.Add(newResource);
+                            }
                         }
                     }
                 }

--- a/ILRepack/Steps/XamlResourcePathPatcherStep.cs
+++ b/ILRepack/Steps/XamlResourcePathPatcherStep.cs
@@ -141,7 +141,14 @@ namespace ILRepacking.Steps
             // we've got no non-primary assembly knowledge so far,
             // that means it's a relative path in the source assembly -> just add the assembly's name as subdirectory
             // /themes/file.xaml -> /library/themes/file.xaml
-            return "/" + sourceAssembly.Name.Name + path;
+            if (primaryAssembly.Name.Name != sourceAssembly.Name.Name)
+            {
+                return "/" + sourceAssembly.Name.Name + path;
+            }
+            else
+            {
+                return path;
+            }
         }
 
         private static bool TryPatchPath(
@@ -151,7 +158,14 @@ namespace ILRepacking.Steps
             string newPath = GetAssemblyPath(primaryAssembly) + "/" + referenceAssembly.Name.Name;
 
             // /library;component/file.xaml -> /primary;component/library/file.xaml
-            patchedPath = path.Replace(referenceAssemblyPath, newPath);
+            if (primaryAssembly.Name.Name != referenceAssembly.Name.Name)
+            {
+                patchedPath = path.Replace(referenceAssemblyPath, newPath);
+            }
+            else
+            {
+                patchedPath = path;
+            }
 
             // if they're modified, we're good!
             return !ReferenceEquals(patchedPath, path);


### PR DESCRIPTION
hi - these are some changes made in a hurry without much attention paid to style or testing. but it works and isn't a lot of code, so if there's interest in the feature i could clean it up.

what it does: 
imagine you have class library Foo.csproj containing WPF controls and 'stuff'. these are compiled to .baml resources and referenced in various magic ways by consuming applications - InitializeComponent, ResourceDictionaries, PackURIs, etc. 

now you want to split out some code into add a sub-layer Foo.Core.csproj - il-repack handles this by embedding the subresources as Foo/Foo.Core/etc.xaml and munging baml paths. that's ok for functionality but it breaks backward compatibility. all consumers of these paths must adjust their assembly references.

in my case i'm actually _transitioning_ from Foo.vbproj to Foo.csproj, so i don't want any observable changes at all. so i added a heuristic whereby baml (and other) elements from wpf generated embedded resources are combined together into a single resource, without renaming, if they have the same exact name.
