### PR TITLE
Do not "clean up" attributes when we copy attributes from the main assembly

### DIFF
--- a/ILRepack/Steps/AttributesRepackStep.cs
+++ b/ILRepack/Steps/AttributesRepackStep.cs
@@ -59,6 +59,7 @@ namespace ILRepacking.Steps
                     _repackCopier.CopyCustomAttributes(mod.CustomAttributes, targetAssemblyMainModule.CustomAttributes, _options.AllowMultipleAssemblyLevelAttributes, null);
                 }
                 CleanupAttributes();
+                RemoveAttributes();
             }
             else if (_options.AttributeFile != null)
             {
@@ -72,18 +73,22 @@ namespace ILRepacking.Steps
                 _repackCopier.CopyCustomAttributes(_repackContext.PrimaryAssemblyDefinition.CustomAttributes, targetAssemblyDefinition.CustomAttributes, null);
                 _repackCopier.CopyCustomAttributes(_repackContext.PrimaryAssemblyMainModule.CustomAttributes, targetAssemblyMainModule.CustomAttributes, null);
                 // TODO: should copy Win32 resources, too
-                CleanupAttributes();
+                RemoveAttributes();
             }
             _repackCopier.CopySecurityDeclarations(_repackContext.PrimaryAssemblyDefinition.SecurityDeclarations, targetAssemblyDefinition.SecurityDeclarations, null);
         }
 
-        void CleanupAttributes()
+        private void CleanupAttributes()
         {
             CleanupAttributes(typeof(CompilationRelaxationsAttribute).FullName, x => x.ConstructorArguments.Count == 1 /* TODO && x.ConstructorArguments[0].Value.Equals(1) */);
             CleanupAttributes(typeof(SecurityTransparentAttribute).FullName, _ => true);
             CleanupAttributes(typeof(SecurityCriticalAttribute).FullName, x => x.ConstructorArguments.Count == 0);
             CleanupAttributes(typeof(AllowPartiallyTrustedCallersAttribute).FullName, x => x.ConstructorArguments.Count == 0);
             CleanupAttributes(typeof(SecurityRulesAttribute).FullName, x => x.ConstructorArguments.Count == 0);
+        }
+
+        private void RemoveAttributes()
+        {
             RemoveAttributes<InternalsVisibleToAttribute>(ca =>
             {
                 String name = (string)ca.ConstructorArguments[0].Value;


### PR DESCRIPTION
In the case when we use the attributes from main target assembly we only want to remove redundant `InternalsVisibleTo` attributes and do not do general attributes clean up. 

This breaks NHibernate build. We merge two .NET 2.0 assemblies (Antlr3 and ReMotion.Linq) into .NET 4 assembly (NHibernate). il-repack removes `SecurityRulesAttribute` from the output assembly as it do not match the .NET 2.0 assemblies (this attribute was introduced in .NET 4.0 and does not exist in .NET 2.0).

When the target assembly has `AllowPartiallyTrustedCallersAttribute` removing `SecurityRulesAttribute` from the output assemlby breaks ANY exception class (or ANY class which implements ISerializable) implemented in merged .NET 2.0 assembly as these classes do not have required `[SecurityCritical]` on `GetObjectData` method.

As a workaround we switched to `/attrs` switch for now which forces the execution path where code does not attempt to "clean up" attributes.