### PR TITLE
changes to excludeinternalizematches for lib

### DIFF
--- a/ILRepack.Tests/RepackOptionsTests.cs
+++ b/ILRepack.Tests/RepackOptionsTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace ILRepack.Tests
 {
@@ -305,6 +306,27 @@ namespace ILRepack.Tests
             Assert.IsNotEmpty(options.InputAssemblies);
             var pattern = options.ExcludeInternalizeMatches.First();
             Assert.IsTrue(pattern.IsMatch(keyFileLines.First()));
+        }
+
+        [Test]
+        public void CanSetExcludeOptionsWithoutCommandLine()
+        {
+            Parse();
+            var r = new Regex("test");
+            options.ExcludeInternalizeMatches.Add(r);
+            CollectionAssert.AreEqual(new[] { r }, options.ExcludeInternalizeMatches);
+        }
+
+        [Test]
+        public void SettingExcludeFileReadsFromFile()
+        {
+            const string excludeFile = "excludefile";
+            var excludeLines = new List<string> { "ex1", "ex2" };
+            Parse();
+            file.Setup(_ => _.ReadAllLines(excludeFile)).Returns(excludeLines.ToArray());
+            options.ExcludeFile = excludeFile;
+            Assert.AreEqual(excludeFile, options.ExcludeFile);
+            CollectionAssert.AreEqual(excludeLines, options.ExcludeInternalizeMatches.Select(r => r.ToString()));
         }
     }
 }

--- a/ILRepack/Steps/TypesRepackStep.cs
+++ b/ILRepack/Steps/TypesRepackStep.cs
@@ -103,14 +103,17 @@ namespace ILRepacking.Steps
         /// </summary>
         private bool ShouldInternalize(string typeFullName)
         {
-            if (_repackOptions.ExcludeInternalizeMatches == null)
-            {
-                return _repackOptions.Internalize;
-            }
+            if (!_repackOptions.Internalize)
+                return false;
+
+            if (_repackOptions.ExcludeInternalizeMatches.Count == 0)
+                return true;
+
             string withSquareBrackets = "[" + typeFullName + "]";
             foreach (Regex r in _repackOptions.ExcludeInternalizeMatches)
                 if (r.IsMatch(typeFullName) || r.IsMatch(withSquareBrackets))
                     return false;
+
             return true;
         }
 


### PR DESCRIPTION
- Initialize the excludeinternalizematches collection so that lib users can add directly.
- Read the ExcludeFile in the property setter.
- Handle the fact the ExcludeInternalizeMatches is no longer null is ShouldInternalize.

related to #185 