### PR TITLE
Expose an $(ILRepack) property for nuget consumers

### DIFF
--- a/ILRepack.props
+++ b/ILRepack.props
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ILRepack>$(MSBuildThisFileDirectory)..\tools\ILRepack.exe</ILRepack>
+  </PropertyGroup>
+</Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,5 +3,5 @@ os: Visual Studio 2015 RC
 install:
 - git submodule update --init --recursive
 build_script:
-- gradlew.bat -is nunit
+- gradlew.bat -is nunit nugetPack
 test: off

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ nugetSpec {
         ],
         files: [
             { file(src: repack.ext.repacked, target: 'tools') },
-            { file(src: "..\\..\\..\\ILRepack.props", target: 'build') }
+            { file(src: project.file('ILRepack.props'), target: 'build') }
         ]
     ]
 }
@@ -107,8 +107,7 @@ task nugetSpecLib(type: com.ullink.NuGetSpec) {
             summary: 'ILRepack is a utility that can be used to merge multiple .NET assemblies into a single assembly (Packaged as library)'
         ],
         files: [
-            { file(src: repack.ext.repackedLib, target: 'lib/net40') },
-            { file(src: "..\\..\\..\\ILRepack.props", target: 'build') }
+            { file(src: repack.ext.repackedLib, target: 'lib/net40') }
         ]
     ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,8 @@ nugetSpec {
             summary: 'ILRepack is a utility that can be used to merge multiple .NET assemblies into a single assembly'
         ],
         files: [
-            { file(src: repack.ext.repacked, target: 'tools') }
+            { file(src: repack.ext.repacked, target: 'tools') },
+            { file(src: 'ILRepack.props', target: 'build') }
         ]
     ]
 }
@@ -106,7 +107,8 @@ task nugetSpecLib(type: com.ullink.NuGetSpec) {
             summary: 'ILRepack is a utility that can be used to merge multiple .NET assemblies into a single assembly (Packaged as library)'
         ],
         files: [
-            { file(src: repack.ext.repackedLib, target: 'lib/net40') }
+            { file(src: repack.ext.repackedLib, target: 'lib/net40') },
+            { file(src: 'ILRepack.props', target: 'build') }
         ]
     ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ nugetSpec {
         ],
         files: [
             { file(src: repack.ext.repacked, target: 'tools') },
-            { file(src: 'ILRepack.props', target: 'build') }
+            { file(src: "..\\..\\..\\ILRepack.props", target: 'build') }
         ]
     ]
 }
@@ -108,7 +108,7 @@ task nugetSpecLib(type: com.ullink.NuGetSpec) {
         ],
         files: [
             { file(src: repack.ext.repackedLib, target: 'lib/net40') },
-            { file(src: 'ILRepack.props', target: 'build') }
+            { file(src: "..\\..\\..\\ILRepack.props", target: 'build') }
         ]
     ]
 }


### PR DESCRIPTION
When using ILRepack as a nuget package, it's often convenient to
be able to execute it in some targets. However, since the nuget
install path depends on the version of the package, it's typically
harder than necessary to figure out the path to `tools`.

This adds a .props file that is automatically imported by nuget
when installed in a project, therefore making it trivial to invoke
the tool by just using the new $(ILRepack) MSBuild property from
anywhere in the project or its imported targets.

Since it's in a .props, it means that even downstream packages that
add a dependency on this package can leverage the tool too without
having to know what version of the ILRepack is in use.