### PR TITLE
Also copy the AssemblyVersionAttribute when using /attr option

### DIFF
--- a/ILRepack/Steps/AttributesRepackStep.cs
+++ b/ILRepack/Steps/AttributesRepackStep.cs
@@ -67,6 +67,10 @@ namespace ILRepacking.Steps
                 AssemblyDefinition attributeAsm = AssemblyDefinition.ReadAssembly(_options.AttributeFile, new ReaderParameters(ReadingMode.Immediate) { AssemblyResolver = _repackContext.GlobalAssemblyResolver });
                 _repackCopier.CopyCustomAttributes(attributeAsm.CustomAttributes, targetAssemblyDefinition.CustomAttributes, null);
                 _repackCopier.CopyCustomAttributes(attributeAsm.CustomAttributes, targetAssemblyMainModule.CustomAttributes, null);
+                if (_options.Version == null)
+                {
+                    targetAssemblyDefinition.Name.Version = attributeAsm.Name.Version;
+                }
                 // TODO: should copy Win32 resources, too
             }
             else


### PR DESCRIPTION
If no explicit version (/ver:) has been defined but a template assembly to copy the attributes from (/attr:), use the assembly version of the template file. That way we get consistent behaviour with ilmerge.

On the IL level the version is not stored as an assembly attribute, however when we retrieve the attributes of an assembly via reflection (or view it in tools like ILSpy), the assembly version appears in System.Reflection.AssemblyVersionAttribute and should match the attribute value of the assembly specified in the /attr: Option.