### PR TITLE
Adds ILRepack targets which automatically repacks all referenced assemblies

### DIFF
--- a/ILRepack.props
+++ b/ILRepack.props
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ILRepack>$(MSBuildThisFileDirectory)..\tools\ILRepack.exe</ILRepack>
+    <ILRepack>"$(MSBuildThisFileDirectory)..\tools\ILRepack.exe"</ILRepack>
+    <ILRepack Condition="'$(OS)' != 'Windows_NT'">mono $(ILRepack)</ILRepack>
     <ILRepackDeleteMergedAssemblies>true</ILRepackDeleteMergedAssemblies>
   </PropertyGroup>
 </Project>

--- a/ILRepack.props
+++ b/ILRepack.props
@@ -2,5 +2,6 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ILRepack>$(MSBuildThisFileDirectory)..\tools\ILRepack.exe</ILRepack>
+    <ILRepackDeleteMergedAssemblies>true</ILRepackDeleteMergedAssemblies>
   </PropertyGroup>
 </Project>

--- a/ILRepack.targets
+++ b/ILRepack.targets
@@ -30,7 +30,7 @@
       <_LibDir Include="@(_AssembliesDir -> Distinct())" />
     </ItemGroup>
 
-    <Exec Command="&quot;$(ILRepack)&quot; @(_LibDir->'/lib:&quot;%(Identity).&quot;', ' ') /internalize $(_KeyFileArg) /targetplatform:&quot;v4,$(FullFrameworkReferenceAssemblyPaths.TrimEnd(\\))&quot; /out:&quot;@(IntermediateAssembly->'%(FullPath)')&quot; &quot;@(IntermediateAssembly->'%(FullPath)')&quot; @(_MergedAssemblies->'&quot;%(FullPath)&quot;', ' ')"
+    <Exec Command="$(ILRepack) @(_LibDir->'/lib:&quot;%(Identity).&quot;', ' ') /internalize $(_KeyFileArg) /targetplatform:&quot;v4,$(FullFrameworkReferenceAssemblyPaths.TrimEnd(\\))&quot; /out:&quot;@(IntermediateAssembly->'%(FullPath)')&quot; &quot;@(IntermediateAssembly->'%(FullPath)')&quot; @(_MergedAssemblies->'&quot;%(FullPath)&quot;', ' ')"
 			  StandardErrorImportance="high"
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"

--- a/ILRepack.targets
+++ b/ILRepack.targets
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemDefinitionGroup>
+    <ReferenceCopyLocalPaths>
+      <!-- By default, ILRepack everything -->
+      <ILRepack>true</ILRepack>
+    </ReferenceCopyLocalPaths>
+  </ItemDefinitionGroup>
+
+  <Target Name="ILRepack"
+			AfterTargets="CoreCompile"
+			DependsOnTargets="CoreCompile"
+			Inputs="@(IntermediateAssembly)"
+			Outputs="$(TargetPath)"
+			Returns="@(_MergedAssemblies)">
+
+    <GetReferenceAssemblyPaths BypassFrameworkInstallChecks="False" TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
+      <Output TaskParameter="FullFrameworkReferenceAssemblyPaths" PropertyName="FullFrameworkReferenceAssemblyPaths" />
+    </GetReferenceAssemblyPaths>
+
+    <PropertyGroup>
+      <_KeyFileArg Condition="'$(AssemblyOriginatorKeyFile)' != ''">/keyfile:&quot;$(AssemblyOriginatorKeyFile)&quot;</_KeyFileArg>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_MergedAssemblies Include="@(ReferenceCopyLocalPaths)"
+                         Condition="'%(ReferenceCopyLocalPaths.ILRepack)' == 'true'" />
+      <_AssembliesDir Include="@(ReferenceCopyLocalPaths -> '%(RootDir)%(Directory)')" />
+      <_LibDir Include="@(_AssembliesDir -> Distinct())" />
+    </ItemGroup>
+
+    <Exec Command="&quot;$(ILRepack)&quot; @(_LibDir->'/lib:&quot;%(Identity).&quot;', ' ') /internalize $(_KeyFileArg) /targetplatform:&quot;v4,$(FullFrameworkReferenceAssemblyPaths.TrimEnd(\\))&quot; /out:&quot;@(IntermediateAssembly->'%(FullPath)')&quot; &quot;@(IntermediateAssembly->'%(FullPath)')&quot; @(_MergedAssemblies->'&quot;%(FullPath)&quot;', ' ')"
+			  StandardErrorImportance="high"
+			  StandardOutputImportance="low"
+			  ConsoleToMSBuild="true"
+			  ContinueOnError="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_ILRepackOutput"/>
+      <Output TaskParameter="ExitCode" PropertyName="_ILRepackExitCode"/>
+    </Exec>
+
+    <Message Importance="high" Text="$(_ILRepackOutput)" Condition="'$(_ILRepackExitCode)' != '0'" />
+    <Error Text="$(_ILRepackOutput)" Condition="'$(_ILRepackExitCode)' != '0'" />
+    <Delete Condition="'$(ILRepackDeleteMergedAssemblies)' == 'true'"
+            Files="@(_MergedAssemblies -> '$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" />
+
+  </Target>
+
+</Project>

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,8 @@ nugetSpec {
         ],
         files: [
             { file(src: repack.ext.repacked, target: 'tools') },
-            { file(src: project.file('ILRepack.props'), target: 'build') }
+            { file(src: project.file('ILRepack.props'), target: 'build') },
+            { file(src: project.file('ILRepack.targets'), target: 'build') }
         ]
     ]
 }


### PR DESCRIPTION
Typical basic usage of ILRepack is to merge all referenced assemblies. The new
ILRepack.targets achieves just that, by extending the item definition for
`@(ReferenceCopyLocalPaths)` and setting the `%(ILRepack)` metadata to `true`
for all of them by default.

Advanced users can easily modify this default behavior by creating a target that
runs before `ILRepack` and tweaking that metadata, such as:

```
  <Target Name="ILRepackAssemblies" DependsOnTargets="ResolveReferences" BeforeTargets="ILRepack" Returns="@(ReferenceCopyLocalPaths)">
    <ItemGroup>
      <ReferenceCopyLocalPaths>
        <ILRepack>false</ILRepack>
        <ILRepack Condition="$([System.String]::new('%(FileName)').StartsWith('Newtonsoft')) Or
                             $([System.String]::new('%(FileName)').StartsWith('NuGet'))">true</ILRepack>
      </ReferenceCopyLocalPaths>
    </ItemGroup>
  </Target>
```

This target runs before ILRepack and flips the default to `false` and explicitly opts in
for assemblies starting with either `Newtonsoft` or `NuGet`.

The ILRepack target uses the `GetReferenceAssemblyPaths` to retrieve the framework path, and
also uses all referenced assembly paths as references for resolution during merging. This means
that if the project could build, ILRepack should be able to load all assemblies too, since it
contains all used references too.

The merged assemblies are deleted if the `$(ILRepackDeleteMergedAssemblies)` is set to `true`
(the default). This property is added to the `.props` file so that it can be easily overriden
in the users' project if needed.

Finally, errors are captured explicitly and turned into an actual MSBuild error, to make it more
prominent and easier to diagnose.