### PR TITLE
Make PdbStr disposable and make best effort to cleanup in its finalizer

### DIFF
--- a/ILRepack.Tests/ILRepack.Tests.csproj
+++ b/ILRepack.Tests/ILRepack.Tests.csproj
@@ -68,6 +68,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandLineTests.cs" />
+    <Compile Include="PdbStrTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RepackLoggerTests.cs" />
     <Compile Include="RepackOptionsTests.cs" />

--- a/ILRepack.Tests/PdbStrTest.cs
+++ b/ILRepack.Tests/PdbStrTest.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using ILRepacking.Steps.SourceServerData;
+using NUnit.Framework;
+
+namespace ILRepack.Tests
+{
+    [TestFixture]
+    class PdbStrTest
+    {
+        private volatile Exception _backgroundException;
+        private UnhandledExceptionEventHandler _handler;
+
+        [SetUp]
+        public void Before()
+        {
+            _handler = (o, e) =>
+            {
+                _backgroundException = (Exception)e.ExceptionObject;
+            };
+            AppDomain.CurrentDomain.UnhandledException += _handler;
+        }
+
+        [TearDown]
+        public void After()
+        {
+            AppDomain.CurrentDomain.UnhandledException -= _handler;
+        }
+
+        [Test]
+        public void ConstructPdbStrInLoop()
+        {
+            for (int i = 0; i < 200; i++)
+            {
+                using (var pdbStr = new PdbStr())
+                {
+                    // allocating some memory to some presure on the GC and cause a cleanup.
+                    var bytes = new byte[65536];
+                    Assert.IsNull(_backgroundException, "error on iteration: {0}", i);
+                }
+            }
+        }
+    }
+}

--- a/ILRepack/Steps/SourceServerData/PdbStr.cs
+++ b/ILRepack/Steps/SourceServerData/PdbStr.cs
@@ -1,11 +1,12 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace ILRepacking.Steps.SourceServerData
 {
-    internal class PdbStr
+    internal class PdbStr : IDisposable
     {
-        private readonly string _pdbStrPath = Path.GetTempFileName();
+        private string _pdbStrPath = Path.GetTempFileName();
 
         public PdbStr()
         {
@@ -46,9 +47,32 @@ namespace ILRepacking.Steps.SourceServerData
             }
         }
 
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+            string file = _pdbStrPath;
+            _pdbStrPath = null;
+            SafeDeleteFile(file);
+        }
+
+        private void SafeDeleteFile(string filePath)
+        {
+            if (filePath != null)
+            {
+                try
+                {
+                    if (File.Exists(filePath))
+                        File.Delete(filePath);
+                }
+                catch { }
+            }
+        }
+
         ~PdbStr()
         {
-            File.Delete(_pdbStrPath);
+            string file = _pdbStrPath;
+            _pdbStrPath = null;
+            SafeDeleteFile(file);
         }
     }
 }


### PR DESCRIPTION
Fixes #191 
- Make PdbStr disposable and wrap File.Delete in a try/catch
- Make SourceServerDataRepackStep IDisposable as well. Manage its lifetime in ILRepack.Repack method to ensure cleanup at the proper time.

I can add more tests, if you want. Actually the real key to detecting this was running tests them in Release mode. I'm not sure if the configuration currently does that.