### PR TITLE
Create new embedded resource for BAMLs if needed #189

### DIFF
--- a/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/ADummyUserControl.xaml
+++ b/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/ADummyUserControl.xaml
@@ -1,0 +1,6 @@
+﻿<UserControl x:Class="AnotherClassLibrary.ADummyUserControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Width="150" Height="50" Background="GreenYellow">
+    <TextBlock Text="Library User Control" HorizontalAlignment="Center" VerticalAlignment="Center" />
+</UserControl>

--- a/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/ADummyUserControl.xaml.cs
+++ b/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/ADummyUserControl.xaml.cs
@@ -1,0 +1,11 @@
+﻿
+namespace AnotherClassLibrary
+{
+    public partial class ADummyUserControl
+    {
+        public ADummyUserControl()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/AnotherClassLibrary.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/AnotherClassLibrary.csproj
@@ -72,12 +72,20 @@
       <DependentUpon>AnotherDummyUserControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="BclAsyncUsage.cs" />
+    <Compile Include="ADummyUserControl.xaml.cs">
+      <DependentUpon>ADummyUserControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WpfWindowStarter.cs" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="AnotherDummyUserControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="ADummyUserControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/WpfWindowStarter.cs
+++ b/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/WpfWindowStarter.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows;
+
+namespace AnotherClassLibrary
+{
+    public class WpfWindowStarter
+    {
+        public static void ShowWindowWithControl()
+        {
+            Window window = new Window();
+            window.Content = new ADummyUserControl();
+            window.Show();
+        }
+    }
+}

--- a/ILRepack.IntegrationTests/Scenarios/DotNet462Application/Program.cs
+++ b/ILRepack.IntegrationTests/Scenarios/DotNet462Application/Program.cs
@@ -1,18 +1,23 @@
-﻿using System;
+﻿using AnotherClassLibrary;
+using System;
 using System.Collections.Immutable;
 using System.Linq;
-using AnotherClassLibrary;
 
 namespace DotNet462Application
 {
     public class Program
     {
+        [STAThread]
         public static void Main(string[] args)
         {
             Console.WriteLine(ImmutableHashSet.Create(1).First());
 
             int number = new BclAsyncUsage().GetNumber().Result;
             Console.WriteLine(number);
+
+            // This app doesn't have any .xaml files, to reproduce the case when
+            // the target library has
+            WpfWindowStarter.ShowWindowWithControl();
         }
     }
 }

--- a/ILRepack/Steps/ResourceProcessing/BamlStreamCollector.cs
+++ b/ILRepack/Steps/ResourceProcessing/BamlStreamCollector.cs
@@ -37,6 +37,8 @@ namespace ILRepacking.Steps.ResourceProcessing
         private readonly BamlGenerator _bamlGenerator;
         private readonly IDictionary<Res, AssemblyDefinition> _bamlStreams = new Dictionary<Res, AssemblyDefinition>();
 
+        public bool HasBamlStreams => _bamlStreams.Count > 0;
+
         public BamlStreamCollector(ILogger logger, IRepackContext repackContext)
         {
             _logger = logger;


### PR DESCRIPTION
There are cases in which an assembly doesn't contain
any .xaml files, thus doesn't have the embedded resource
that would contain them. Now, we'll create a new embedded
resource if needed

This fixes #189