### PR TITLE
"Rename internalized types" option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ _NCrunch*
 *.sln.cache
 *.DotSettings
 /.vs
+/.idea

--- a/ILRepack.Tests/RepackOptionsTests.cs
+++ b/ILRepack.Tests/RepackOptionsTests.cs
@@ -335,7 +335,7 @@ namespace ILRepack.Tests
         {
             commandLine.Setup(cmd => cmd.HasOption("internalize")).Returns(true);
             commandLine.Setup(cmd => cmd.Option("internalize")).Returns(string.Empty);
-            commandLine.Setup(cmd => cmd.Modifier("renameInternalized")).Returns(renameInternalized);
+            commandLine.Setup(cmd => cmd.Modifier("renameinternalized")).Returns(renameInternalized);
             Parse();
             Assert.AreEqual(renameInternalized, options.RenameInternalized);
         }
@@ -349,7 +349,7 @@ namespace ILRepack.Tests
             
             commandLine.Setup(cmd => cmd.HasOption("internalize")).Returns(true);
             commandLine.Setup(cmd => cmd.Option("internalize")).Returns(string.Empty);
-            commandLine.Setup(cmd => cmd.Modifier("renameInternalized")).Returns(true);
+            commandLine.Setup(cmd => cmd.Modifier("renameinternalized")).Returns(true);
             Parse();
             options.Validate();
             Assert.DoesNotThrow(() => options.Validate());
@@ -362,7 +362,7 @@ namespace ILRepack.Tests
             commandLine.Setup(cmd => cmd.Option("out")).Returns("filename");
             commandLine.Setup(cmd => cmd.OtherAguments).Returns(inputAssemblies.ToArray());
             
-            commandLine.Setup(cmd => cmd.Modifier("renameInternalized")).Returns(true);
+            commandLine.Setup(cmd => cmd.Modifier("renameinternalized")).Returns(true);
             Parse();
             Assert.Throws<InvalidOperationException>(() => options.Validate());
         }

--- a/ILRepack.Tests/RepackOptionsTests.cs
+++ b/ILRepack.Tests/RepackOptionsTests.cs
@@ -328,5 +328,43 @@ namespace ILRepack.Tests
             Assert.AreEqual(excludeFile, options.ExcludeFile);
             CollectionAssert.AreEqual(excludeLines, options.ExcludeInternalizeMatches.Select(r => r.ToString()));
         }
+                
+        [TestCase(false)]
+        [TestCase(true)]
+        public void WithRenameInternalizedSet_WithInternalize__Parse__RenameInternalized_ShouldBeCorrect(bool renameInternalized)
+        {
+            commandLine.Setup(cmd => cmd.HasOption("internalize")).Returns(true);
+            commandLine.Setup(cmd => cmd.Option("internalize")).Returns(string.Empty);
+            commandLine.Setup(cmd => cmd.Modifier("renameInternalized")).Returns(renameInternalized);
+            Parse();
+            Assert.AreEqual(renameInternalized, options.RenameInternalized);
+        }
+
+        [Test]
+        public void WithRenameInternalizedSet_WithInternalize__Parse__NoException()
+        {
+            var inputAssemblies = new List<string> { "A", "B", "C" };
+            commandLine.Setup(cmd => cmd.Option("out")).Returns("filename");
+            commandLine.Setup(cmd => cmd.OtherAguments).Returns(inputAssemblies.ToArray());
+            
+            commandLine.Setup(cmd => cmd.HasOption("internalize")).Returns(true);
+            commandLine.Setup(cmd => cmd.Option("internalize")).Returns(string.Empty);
+            commandLine.Setup(cmd => cmd.Modifier("renameInternalized")).Returns(true);
+            Parse();
+            options.Validate();
+            Assert.DoesNotThrow(() => options.Validate());
+        }
+
+        [Test]
+        public void WithRenameInternalizedSet_WithoutInternalize__Parse__ThrowsInvalidOperationException()
+        {
+            var inputAssemblies = new List<string> { "A", "B", "C" };
+            commandLine.Setup(cmd => cmd.Option("out")).Returns("filename");
+            commandLine.Setup(cmd => cmd.OtherAguments).Returns(inputAssemblies.ToArray());
+            
+            commandLine.Setup(cmd => cmd.Modifier("renameInternalized")).Returns(true);
+            Parse();
+            Assert.Throws<InvalidOperationException>(() => options.Validate());
+        }
     }
 }

--- a/ILRepack/RepackImporter.cs
+++ b/ILRepack/RepackImporter.cs
@@ -140,7 +140,7 @@ namespace ILRepacking
             {
                 // rename the type previously imported.
                 // renaming the new one before import made Cecil throw an exception.
-                string other = "<" + Guid.NewGuid() + ">" + nt.Name;
+                string other = GenerateName(nt);
                 _logger.Info("Renaming " + nt.FullName + " into " + other);
                 nt.Name = other;
                 nt = CreateType(type, col, internalize, null);
@@ -197,7 +197,19 @@ namespace ILRepacking
                 }
             }
 
+            if (internalize && _options.RenameInternalized)
+            {
+                string newName = GenerateName(nt);
+                _logger.Verbose("Renaming " + nt.FullName + " into " + newName);
+                nt.Name = newName;
+            }
+
             return nt;
+        }
+
+        private string GenerateName(TypeDefinition typeDefinition)
+        {
+            return "<" + Guid.NewGuid() + ">" + typeDefinition.Name;
         }
 
         private bool ShouldDrop<TMember>(TMember member) where TMember : ICustomAttributeProvider, IMemberDefinition

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -98,6 +98,7 @@ namespace ILRepacking
         }
 
         public string RepackDropAttribute { get; set; }
+        public bool RenameInternalized { get; set; }
 
         private readonly Hashtable allowedDuplicateTypes = new Hashtable();
         private readonly List<string> allowedDuplicateNameSpaces = new List<string>();
@@ -165,6 +166,8 @@ namespace ILRepacking
                 // this file shall contain one regex per line to compare agains FullName of types NOT to internalize
                 ExcludeFile = cmd.Option("internalize");
             }
+
+            RenameInternalized = cmd.Modifier("renameInternalized");
             KeyFile = cmd.Option("keyfile");
             KeyContainer = cmd.Option("keycontainer");
             Log = cmd.HasOption("log");
@@ -261,6 +264,9 @@ namespace ILRepacking
 
             if ((KeyFile != null) && !file.Exists(KeyFile))
                 throw new ArgumentException($"KeyFile does not exist: '{KeyFile}'.");
+            
+            if (RenameInternalized && !Internalize)
+                throw new InvalidOperationException("Option 'renameInternalized' is only valid with 'internalize'.");
         }
 
         public IList<string> ResolveFiles()

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -167,7 +167,7 @@ namespace ILRepacking
                 ExcludeFile = cmd.Option("internalize");
             }
 
-            RenameInternalized = cmd.Modifier("renameInternalized");
+            RenameInternalized = cmd.Modifier("renameinternalized");
             KeyFile = cmd.Option("keyfile");
             KeyContainer = cmd.Option("keycontainer");
             Log = cmd.HasOption("log");

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -256,6 +256,9 @@ namespace ILRepacking
             if (!string.IsNullOrEmpty(AttributeFile) && CopyAttributes)
                 throw new InvalidOperationException("Option 'attr' can not be used with 'copyattrs'.");
 
+            if (RenameInternalized && !Internalize)
+                throw new InvalidOperationException("Option 'renameInternalized' is only valid with 'internalize'.");
+            
             if (string.IsNullOrEmpty(OutputFile))
                 throw new ArgumentException("No output file given.");
 
@@ -264,9 +267,6 @@ namespace ILRepacking
 
             if ((KeyFile != null) && !file.Exists(KeyFile))
                 throw new ArgumentException($"KeyFile does not exist: '{KeyFile}'.");
-            
-            if (RenameInternalized && !Internalize)
-                throw new InvalidOperationException("Option 'renameInternalized' is only valid with 'internalize'.");
         }
 
         public IList<string> ResolveFiles()

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Syntax: ILRepack.exe [options] /out:<path> <path_to_primary> [<other_assemblies>
  - /xmldocs             merges XML documentation as well
  - /lib:<path>          adds the path to the search directories for referenced assemblies (can be specified multiple times)
  - /internalize         sets all types but the ones from the first assembly 'internal'
+ - /renameInternalized  rename all internalized types
  - /delaysign           sets the key, but don't sign the assembly
  - /usefullpublickeyforreferences - NOT IMPLEMENTED
  - /align               - NOT IMPLEMENTED


### PR DESCRIPTION
Add ILRepack option `/renameInternalized` which force ILRepack to rename all types from other assemblies during repack, like duplicate types renaming:
`Problem` -> `<7fdc160b-0b9b-4c55-bc82-341aa12b7ab4>Problem`.

Issue: https://github.com/gluck/il-repack/issues/233