### PR TITLE
Fix netstandard2 + .NET 4.6.2

### DIFF
--- a/ILRepack.IntegrationTests/Scenarios.cs
+++ b/ILRepack.IntegrationTests/Scenarios.cs
@@ -47,6 +47,12 @@ namespace ILRepack.IntegrationTests
             RunScenario("DotNet462Application");
         }
 
+        [Test]
+        public void GivenDotNet462AppUsingNetStandard2LibrarySetAndReflection_MergedApplicationRunsSuccessfully()
+        {
+            RunScenario("DotNet462NetStandard2");
+        }
+
         private void RunScenario(string scenarioName)
         {
             string scenarioExecutable = GetScenarioExecutable(scenarioName);

--- a/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/App.config
+++ b/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+</configuration>

--- a/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/DotNet462NetStandard2.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/DotNet462NetStandard2.csproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{90F1C943-3C23-4091-B07F-0B34748AE056}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DotNet462NetStandard2</RootNamespace>
+    <AssemblyName>DotNet462NetStandard2</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>
+    </StartupObject>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.1\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>REM Ensure re-build is done every time to use latest built ILRepack version
+del /q $(ProjectDir)\obj\$(ConfigurationName)\*.*
+
+mkdir $(TargetDir)\merged
+$(SolutionDir)ILRepack\bin\$(ConfigurationName)\ILRepack.exe /verbose /log /out:$(TargetDir)\merged\$(TargetFileName) $(TargetPath) Microsoft.Win32.Primitives.dll netstandard.dll System.AppContext.dll System.Buffers.dll System.Collections.Concurrent.dll System.Collections.dll System.Collections.NonGeneric.dll System.Collections.Specialized.dll System.ComponentModel.dll System.ComponentModel.EventBasedAsync.dll System.ComponentModel.Primitives.dll System.ComponentModel.TypeConverter.dll System.Console.dll System.Data.Common.dll System.Diagnostics.Contracts.dll System.Diagnostics.Debug.dll System.Diagnostics.FileVersionInfo.dll System.Diagnostics.Process.dll System.Diagnostics.StackTrace.dll System.Diagnostics.TextWriterTraceListener.dll System.Diagnostics.Tools.dll System.Diagnostics.TraceSource.dll System.Diagnostics.Tracing.dll System.Drawing.Primitives.dll System.Dynamic.Runtime.dll System.Globalization.Calendars.dll System.Globalization.dll System.Globalization.Extensions.dll System.IO.Compression.dll System.IO.Compression.ZipFile.dll System.IO.dll System.IO.FileSystem.dll System.IO.FileSystem.DriveInfo.dll System.IO.FileSystem.Primitives.dll System.IO.FileSystem.Watcher.dll System.IO.IsolatedStorage.dll System.IO.MemoryMappedFiles.dll System.IO.Pipes.dll System.IO.UnmanagedMemoryStream.dll System.Linq.dll System.Linq.Expressions.dll System.Linq.Parallel.dll System.Linq.Queryable.dll System.Net.Http.dll System.Net.NameResolution.dll System.Net.NetworkInformation.dll System.Net.Ping.dll System.Net.Primitives.dll System.Net.Requests.dll System.Net.Security.dll System.Net.Sockets.dll System.Net.WebHeaderCollection.dll System.Net.WebSockets.Client.dll System.Net.WebSockets.dll System.ObjectModel.dll System.Reflection.dll System.Reflection.Extensions.dll System.Reflection.Primitives.dll System.Resources.Reader.dll System.Resources.ResourceManager.dll System.Resources.Writer.dll System.Runtime.CompilerServices.Unsafe.dll System.Runtime.CompilerServices.VisualC.dll System.Runtime.dll System.Runtime.Extensions.dll System.Runtime.Handles.dll System.Runtime.InteropServices.dll System.Runtime.InteropServices.RuntimeInformation.dll System.Runtime.Numerics.dll System.Runtime.Serialization.Formatters.dll System.Runtime.Serialization.Json.dll System.Runtime.Serialization.Primitives.dll System.Runtime.Serialization.Xml.dll System.Security.Claims.dll System.Security.Cryptography.Algorithms.dll System.Security.Cryptography.Csp.dll System.Security.Cryptography.Encoding.dll System.Security.Cryptography.Primitives.dll System.Security.Cryptography.X509Certificates.dll System.Security.Principal.dll System.Security.SecureString.dll System.Text.Encoding.dll System.Text.Encoding.Extensions.dll System.Text.RegularExpressions.dll System.Threading.dll System.Threading.Overlapped.dll System.Threading.Tasks.dll System.Threading.Tasks.Parallel.dll System.Threading.Thread.dll System.Threading.ThreadPool.dll System.Threading.Timer.dll System.ValueTuple.dll System.Xml.ReaderWriter.dll System.Xml.XDocument.dll System.Xml.XmlDocument.dll System.Xml.XmlSerializer.dll System.Xml.XPath.dll System.Xml.XPath.XDocument.dll
+
+exit /b %25ERRORLEVEL%25</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/Program.cs
+++ b/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/Program.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Buffers;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace DotNet462NetStandard2
+{
+    class Program
+    {
+        static unsafe int Main(string[] args)
+        {
+            int a = 100500;
+            var b = Marshal.AllocHGlobal(new IntPtr(4));
+            Unsafe.Write(b.ToPointer(), a);
+            var c = Unsafe.Read<int>(b.ToPointer());
+
+            if (a != c)
+            {
+                Console.WriteLine("Unsafe failed");
+                return -1;
+            }
+            else
+            {
+                Console.WriteLine("Unsafe success");
+            }
+
+            var arr = ArrayPool<int>.Shared.Rent(10);
+
+            ArrayPool<int>.Shared.Return(arr);
+
+            Marshal.FreeHGlobal(b);
+
+            var types = Assembly.GetEntryAssembly().GetTypes();
+
+            if (types.Any(t => t.Name == "Program"))
+            {
+                Console.WriteLine("Reflection success");
+            }
+            else
+            {
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/Properties/AssemblyInfo.cs
+++ b/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DotNet462NetStandard2")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DotNet462NetStandard2")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a85b89e0-7552-4fe9-8355-478a652fe4f2")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/packages.config
+++ b/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Buffers" version="4.5.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net462" />
+</packages>

--- a/ILRepack.sln
+++ b/ILRepack.sln
@@ -43,6 +43,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WPFThemingAndLibraryStyles"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNet462Application", "ILRepack.IntegrationTests\Scenarios\DotNet462Application\DotNet462Application.csproj", "{EECC6459-78C6-4A08-9039-DE37E75866E6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNet462NetStandard2", "ILRepack.IntegrationTests\Scenarios\DotNet462NetStandard2\DotNet462NetStandard2.csproj", "{90F1C943-3C23-4091-B07F-0B34748AE056}"
+	ProjectSection(ProjectDependencies) = postProject
+		{4A253A60-D998-4CA2-B9D5-46567A2FBF80} = {4A253A60-D998-4CA2-B9D5-46567A2FBF80}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug_unix|Any CPU = Debug_unix|Any CPU
@@ -126,6 +131,12 @@ Global
 		{EECC6459-78C6-4A08-9039-DE37E75866E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EECC6459-78C6-4A08-9039-DE37E75866E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EECC6459-78C6-4A08-9039-DE37E75866E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90F1C943-3C23-4091-B07F-0B34748AE056}.Debug_unix|Any CPU.ActiveCfg = Debug|Any CPU
+		{90F1C943-3C23-4091-B07F-0B34748AE056}.Debug_unix|Any CPU.Build.0 = Debug|Any CPU
+		{90F1C943-3C23-4091-B07F-0B34748AE056}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90F1C943-3C23-4091-B07F-0B34748AE056}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90F1C943-3C23-4091-B07F-0B34748AE056}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90F1C943-3C23-4091-B07F-0B34748AE056}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -139,6 +150,7 @@ Global
 		{A183949D-1057-4585-B76D-F86CA28C69D0} = {04819B25-ABEA-46F7-90D5-149C8304F67F}
 		{6A827942-BEEF-4E49-A3A4-306E21428E85} = {04819B25-ABEA-46F7-90D5-149C8304F67F}
 		{EECC6459-78C6-4A08-9039-DE37E75866E6} = {04819B25-ABEA-46F7-90D5-149C8304F67F}
+		{90F1C943-3C23-4091-B07F-0B34748AE056} = {04819B25-ABEA-46F7-90D5-149C8304F67F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {54C7CB02-6231-428F-BBD0-113CC9852908}

--- a/ILRepack/MappingHandler.cs
+++ b/ILRepack/MappingHandler.cs
@@ -92,10 +92,21 @@ namespace ILRepacking
             throw new Exception("Unsupported scope: "+ scope);
         }
 
-        public TypeReference GetExportedRemappedType(TypeReference type)
+        private TypeReference GetRootReference(TypeReference type)
         {
             TypeReference other;
             if (type.Scope != null && exportMappings.TryGetValue(GetTypeKey(type), out other))
+            {
+                var next = GetRootReference(other);
+                return next ?? other;
+            }
+            return null;
+        }
+
+        public TypeReference GetExportedRemappedType(TypeReference type)
+        {
+            TypeReference other = GetRootReference(type);
+            if (other != null)
             {
                 // ElementType is used when serializing the Assembly.
                 // It should match the actual type (e.g., Boolean for System.Boolean). But because of forwarded types, this is not known at read time, thus having to fix it here.

--- a/ILRepack/RepackImporter.cs
+++ b/ILRepack/RepackImporter.cs
@@ -64,6 +64,15 @@ namespace ILRepacking
                 // I've never seen an exported type redirected to a module, doing so would be blind guessing
                 scope = type.Scope;
             }
+            if (type.IsForwarder)
+            {
+                // Skip duplicated forwarders
+                var fullName = type.FullName;
+                if (col.Any(t => t.IsForwarder && t.FullName == fullName))
+                {
+                    return;
+                }
+            }
             var nt = new ExportedType(type.Namespace, type.Name, module, scope)
             {
                 Attributes = type.Attributes,


### PR DESCRIPTION
netstandard2 support layer for .NET 4.6.2-4.7.1 abuses redirects - it has both chained redirects (System.Object is redirected from System.Runtime.dll to netstandard.dll to mscorlib.dll) and duplicated redirects (System.Data.* types are redirected to System.Data.dll by both System.Data.Common.dll and netstandard.dll).
First case ends up with Assembly.GetTypes() throwing due to missing types and second case ends up with startup crash due to duplicated types.