### PR TITLE
Handle versions in XAML paths

### DIFF
--- a/ILRepack.Tests/Steps/XamlResourcePathPatcherStepTests.cs
+++ b/ILRepack.Tests/Steps/XamlResourcePathPatcherStepTests.cs
@@ -70,6 +70,14 @@ namespace ILRepack.Tests.Steps
                     "/MainAssembly;component/ClassLibrary/ButtonStyles.xaml"),
 
                 new TestCaseData(
+                    "/ClassLibrary;V2.0.0;component/ButtonStyles.xaml",
+                    "/MainAssembly;component/ClassLibrary/ButtonStyles.xaml"),
+
+                new TestCaseData(
+                    "/ClassLibrary;v2.0.0;component/ButtonStyles.xaml",
+                    "/MainAssembly;component/ClassLibrary/ButtonStyles.xaml"),
+
+                new TestCaseData(
                     "/themes/ButtonStyles.xaml",
                     "/themes/ButtonStyles.xaml"),
 

--- a/ILRepack/Steps/XamlResourcePathPatcherStep.cs
+++ b/ILRepack/Steps/XamlResourcePathPatcherStep.cs
@@ -17,6 +17,7 @@ using Mono.Cecil;
 using Mono.Cecil.Cil;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace ILRepacking.Steps
 {
@@ -25,6 +26,7 @@ namespace ILRepacking.Steps
     {
         private readonly ILogger _logger;
         private readonly IRepackContext _repackContext;
+        private static readonly Regex VersionRegex = new Regex("v(.?\\d)+;", RegexOptions.IgnoreCase);
 
         public XamlResourcePathPatcherStep(ILogger logger, IRepackContext repackContext)
         {
@@ -147,6 +149,11 @@ namespace ILRepacking.Steps
         private static bool TryPatchPath(
             string path, AssemblyDefinition primaryAssembly, AssemblyDefinition referenceAssembly, out string patchedPath)
         {
+            // get rid of potential versions in the path
+            // Starting with a new .NET MSBuild version, in case the project is built
+            // via a new-format .csproj, the version is appended
+            path = VersionRegex.Replace(path, string.Empty);
+
             string referenceAssemblyPath = GetAssemblyPath(referenceAssembly);
             string newPath = GetAssemblyPath(primaryAssembly) + "/" + referenceAssembly.Name.Name;
 


### PR DESCRIPTION
Starting with a new .NET MSBuild version, in case the project is built
via a new-format .csproj, the version is appended