### PR TITLE
fixed possible <Guid><Module> as type after multiple repacks with /re…

### DIFF
--- a/ILRepack/RepackImporter.cs
+++ b/ILRepack/RepackImporter.cs
@@ -206,7 +206,7 @@ namespace ILRepacking
                 }
             }
 
-            if (internalize && _options.RenameInternalized)
+            if (internalize && _options.RenameInternalized && !IsModuleTag(nt))
             {
                 string newName = GenerateName(nt);
                 _logger.Verbose("Renaming " + nt.FullName + " into " + newName);
@@ -215,6 +215,10 @@ namespace ILRepacking
 
             return nt;
         }
+
+        //Module tag must't be renamed. Otherwise after two repacks .dll will contain <Model> and <Guid><Model>
+        //Assembly.Load() will load <Guid><Module> as type and crush
+        private static bool IsModuleTag(TypeDefinition nt) => nt.FullName == "<Module>";
 
         private string GenerateName(TypeDefinition typeDefinition)
         {


### PR DESCRIPTION
Fixed bug:

1. Repack with /renameInternalized to `A.dll`
2. Repack some project which depends on `A.dll` to `B.dll`
3. Try to `Assembly.Load("B.dll")`. 
4. Catch exception

After second repack package will contain `<Module>` and `<Guid><Model>`. Second will be loaded as type 