### PR TITLE
Xaml source not from primary or reference assembly

### DIFF
--- a/ILRepack/Steps/ResourceProcessing/BamlResourcePatcher.cs
+++ b/ILRepack/Steps/ResourceProcessing/BamlResourcePatcher.cs
@@ -92,21 +92,38 @@ namespace ILRepacking.Steps.ResourceProcessing
             }
         }
 
+        private void ProcessRecord(PIMappingRecord record, AssemblyDefinition containingAssembly)
+        {
+            if (FixXmlNamespace(record.XmlNamespace, out string fixedNamespace))
+            {
+                record.XmlNamespace = fixedNamespace;
+            }
+        }
+
         private void ProcessRecord(XmlnsPropertyRecord record, AssemblyDefinition containingAssembly)
         {
-            string xmlNamespace = record.XmlNamespace;
+            if (FixXmlNamespace(record.XmlNamespace, out string fixedNamespace))
+            {
+                record.XmlNamespace = fixedNamespace;
+            }
+        }
+
+        private bool FixXmlNamespace(string xmlNamespace, out string fixedNamespace)
+        {
+            fixedNamespace = xmlNamespace;
             const string AssemblyDef = "assembly=";
             int assemblyStart = xmlNamespace.IndexOf(AssemblyDef, StringComparison.Ordinal);
             if (assemblyStart == -1)
-                return;
+                return false;
 
             // Make sure it is one of the merged assemblies
             string xmlAssembly = xmlNamespace.Substring(assemblyStart + AssemblyDef.Length);
             if (_mainAssembly.Name.Name != xmlAssembly && _otherAssemblies.All(x => x.Name.Name != xmlAssembly))
-                return;
+                return false;
 
             string xmlNsWithoutAssembly = xmlNamespace.Substring(0, assemblyStart);
-            record.XmlNamespace = string.Format("{0}{1}{2}", xmlNsWithoutAssembly, AssemblyDef, _mainAssembly.Name.Name);
+            fixedNamespace = string.Format("{0}{1}{2}", xmlNsWithoutAssembly, AssemblyDef, _mainAssembly.Name.Name);
+            return true;
         }
 
         private void ProcessRecord(TypeInfoRecord record, AssemblyDefinition containingAssembly)

--- a/ILRepack/Steps/XamlResourcePathPatcherStep.cs
+++ b/ILRepack/Steps/XamlResourcePathPatcherStep.cs
@@ -129,13 +129,13 @@ namespace ILRepacking.Steps
             string patchedPath = path;
             if (primaryAssembly == sourceAssembly)
             {
-                if (otherAssemblies.Any(assembly => TryPatchPath(path, primaryAssembly, assembly, true, out patchedPath)))
+                if (otherAssemblies.Any(assembly => TryPatchPath(path, primaryAssembly, assembly, otherAssemblies, true, out patchedPath)))
                     return patchedPath;
 
                 return path;
             }
 
-            if (TryPatchPath(path, primaryAssembly, sourceAssembly, false, out patchedPath))
+            if (TryPatchPath(path, primaryAssembly, sourceAssembly, otherAssemblies, false, out patchedPath))
                 return patchedPath;
 
             if (!path.EndsWith(".xaml"))
@@ -148,7 +148,12 @@ namespace ILRepacking.Steps
         }
 
         private static bool TryPatchPath(
-            string path, AssemblyDefinition primaryAssembly, AssemblyDefinition referenceAssembly, bool isPrimarySameAsSource, out string patchedPath)
+            string path, 
+            AssemblyDefinition primaryAssembly,
+            AssemblyDefinition referenceAssembly,
+            IList<AssemblyDefinition> otherAssemblies, 
+            bool isPrimarySameAsSource,
+            out string patchedPath)
         {
             // get rid of potential versions in the path
             // Starting with a new .NET MSBuild version, in case the project is built
@@ -169,7 +174,14 @@ namespace ILRepacking.Steps
                 {
                     if (m.Groups.Count == 2)
                     {
-                        return GetAssemblyPath(primaryAssembly) + "/" + m.Groups[1].Value;
+                        if (otherAssemblies.Any(a => a.Name.Name == m.Groups[1].Value))
+                        {
+                            return GetAssemblyPath(primaryAssembly) + "/" + m.Groups[1].Value;
+                        }
+                        else
+                        {
+                            return m.Value;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
If there are 3 assemblies: Primary, Reference, Source the TryPatchPath would not patch the path and a wrong would be generated as relative path (eg. /Reference**pack://**...)

Primary: content does not matter
Source: contains a ResourceDictionary (ex. Resources/Test.xaml) which we want to add to Reference
Reference: contains a xaml with code like this:
<ResourceDictionary Source="/Source;component/Resources/Test.xaml" />

**Without** fix it would create:
`<ResourceDictionary Source="/Reference/Source;component/Resources/Test.xaml" />`

**With** fix it create:
`<ResourceDictionary Source="/Primary;component/Source/Resources/Test.xaml" />`

See attached example application with arguments:
[args.txt](https://github.com/gluck/il-repack/files/4724177/args.txt)
[ILRepackSourceFix.zip](https://github.com/gluck/il-repack/files/4724178/ILRepackSourceFix.zip)

