### PR TITLE
Fixed Internalize behavior for the Primary or main assembly

### DIFF
--- a/ILRepack/ILRepack.csproj
+++ b/ILRepack/ILRepack.csproj
@@ -29,33 +29,6 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
-
-    <IsPackable>true</IsPackable>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <NoPackageAnalysis>true</NoPackageAnalysis>
-    <LangVersion>7.3</LangVersion>
-    <PackageOutputPath>c:\nupkgs</PackageOutputPath>
-    <!-- nuspec -->
-    <PackageId>ILRepack.NETStandard</PackageId>
-    <Title>ILRepack - Open-source alternative to ILMerge</Title>
-    <Description>
-        ILRepack is meant at replacing ILMerge / Mono.Merge.
-        The former being closed-source, impossible to customize, slow, resource consuming and many more. The later being deprecated, unsupported, and based on an old version of Mono.Cecil.
-        ILRepack is a utility that can be used to merge multiple .NET assemblies into a single assembly.
-    </Description>
-    <Platforms>AnyCPU</Platforms>
-    <Authors>Francois Valdy</Authors>
-    <Owners>Francois Valdy</Owners>
-    <Product>ILRepack</Product>
-    <Copyright>Copyright Francois Valdy 2011-2015</Copyright>
-    <NeutralLanguage>en-US</NeutralLanguage>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/peters/il-repack</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/peters/il-repack.git</RepositoryUrl>
-    <PackageReleaseNotes>See $(PackageProjectUrl)/blob/master/CHANGELOG.md#v$(VersionPrefix.Replace('.','')) for release notes.</PackageReleaseNotes>
-    <RepositoryType>git</RepositoryType>
-    <!-- /nuspec -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ILRepack/ILRepack.csproj
+++ b/ILRepack/ILRepack.csproj
@@ -29,6 +29,33 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+
+    <IsPackable>true</IsPackable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <LangVersion>7.3</LangVersion>
+    <PackageOutputPath>c:\nupkgs</PackageOutputPath>
+    <!-- nuspec -->
+    <PackageId>ILRepack.NETStandard</PackageId>
+    <Title>ILRepack - Open-source alternative to ILMerge</Title>
+    <Description>
+        ILRepack is meant at replacing ILMerge / Mono.Merge.
+        The former being closed-source, impossible to customize, slow, resource consuming and many more. The later being deprecated, unsupported, and based on an old version of Mono.Cecil.
+        ILRepack is a utility that can be used to merge multiple .NET assemblies into a single assembly.
+    </Description>
+    <Platforms>AnyCPU</Platforms>
+    <Authors>Francois Valdy</Authors>
+    <Owners>Francois Valdy</Owners>
+    <Product>ILRepack</Product>
+    <Copyright>Copyright Francois Valdy 2011-2015</Copyright>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/peters/il-repack</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/peters/il-repack.git</RepositoryUrl>
+    <PackageReleaseNotes>See $(PackageProjectUrl)/blob/master/CHANGELOG.md#v$(VersionPrefix.Replace('.','')) for release notes.</PackageReleaseNotes>
+    <RepositoryType>git</RepositoryType>
+    <!-- /nuspec -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ILRepack/Steps/ReferencesFixStep.cs
+++ b/ILRepack/Steps/ReferencesFixStep.cs
@@ -59,7 +59,9 @@ namespace ILRepacking.Steps
             }
             foreach (var r in targetAssemblyMainModule.Types)
             {
-                if(!_repackContext.PrimaryAssemblyMainModule.Types.Any(x=> x.FullName == r.FullName))
+                //Visibility should not be changed for Methods of Types that are on the Primary Assembly,
+                //when internalize is true
+                if(!_options.Internalize || !_repackContext.PrimaryAssemblyMainModule.Types.Any(x=> x.FullName == r.FullName))
                     fixator.FixMethodVisibility(r);
             }
             fixator.FixReferences(_repackContext.TargetAssemblyDefinition.MainModule.ExportedTypes);

--- a/ILRepack/Steps/ReferencesFixStep.cs
+++ b/ILRepack/Steps/ReferencesFixStep.cs
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+using System.Linq;
 using Mono.Cecil;
 
 namespace ILRepacking.Steps
@@ -58,7 +59,8 @@ namespace ILRepacking.Steps
             }
             foreach (var r in targetAssemblyMainModule.Types)
             {
-                fixator.FixMethodVisibility(r);
+                if(!_repackContext.PrimaryAssemblyMainModule.Types.Any(x=> x.FullName == r.FullName))
+                    fixator.FixMethodVisibility(r);
             }
             fixator.FixReferences(_repackContext.TargetAssemblyDefinition.MainModule.ExportedTypes);
             fixator.FixReferences(_repackContext.TargetAssemblyDefinition.CustomAttributes);


### PR DESCRIPTION
Some assemblies have a problem with the repacking, for example Npgsql v4.1.5.0.

In this case the npgsql assembly method (TextHandler.Read) has a "Reduce Access" error since the method of the derived class is changed from public to internal protected breaking everything.

This change makes sure that FixMethodVisibility is not called for Methods of types of the Main assembly when internalize flag is TRUE.  

This fixes issue #219.