### PR TITLE
Add NuGet license information to .nuspec

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,10 +79,14 @@ def commonNuspecMetadata = [
     dependencies: []
 ]
 
+def commonNuspecMetadataClosures = [
+    {d -> delegate.license(type: 'expression', 'Apache-2.0') }
+]
+
 // nuget package for upload to nuget
 nugetSpec {
     nuspec = [
-        metadata: commonNuspecMetadata + [
+        metadata: commonNuspecMetadataClosures + commonNuspecMetadata + [
             id: archivesBaseName,
             description: '''ILRepack is meant at replacing ILMerge / Mono.Merge.
             The former being closed-source, impossible to customize, slow, resource consuming and many more. The later being deprecated, unsupported, and based on an old version of Mono.Cecil.''',
@@ -97,7 +101,7 @@ nugetSpec {
 
 task nugetSpecLib(type: com.ullink.NuGetSpec) {
     nuspec = [
-        metadata: commonNuspecMetadata + [
+        metadata: commonNuspecMetadataClosures +  commonNuspecMetadata + [
             id: archivesBaseName+'.Lib',
             description: '''ILRepack is meant at replacing ILMerge / Mono.Merge.
             The former being closed-source, impossible to customize, slow, resource consuming and many more. The later being deprecated, unsupported, and based on an old version of Mono.Cecil.


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/nuget/reference/nuspec#license
Context: https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#important-nuget-package-metadata
Context: https://docs.clearlydefined.io/curation-guidelines

Certain internal Microsoft tools check NuGet license information by
using [ClearlyDefined curated data][0] to determine verified license
information for packages which don't "clearly define" their license.

The `ILRepack` and `ILRepack.Lib` NuGet packages do no specify *any*
license information within their `.nuspec` files.

Update `build.groovy` so that the generated `.nuspec` files contain
the [`<license/>][1] element:

	<license type="expression">Apache-2.0</license>

The value of the `<license/>` element must be an [SPDX license][2]
identifier.

This is slightly complicated by the fact that I can't find an easy
way to get [`com.ullink.nuget` to emit XML attributes][2].
Fortunately, if it processes a closure, we can get access to the
underlying `MarkupBuilder` instance, which allows us to create an
XML element that contains both attributes and content.

[0]: https://github.com/clearlydefined/curated-data/
[1]: https://docs.microsoft.com/en-us/nuget/reference/nuspec#license
[2]: https://spdx.org/licenses/
[3]: https://github.com/Itiviti/gradle-nuget-plugin/blob/045fc691a704cda3fd6afcc43acc7e820a868926/src/main/groovy/com/ullink/NuGetSpec.groovy#L43-L63