### PR TITLE
1、Distinguish between normal and error output logs, which is convenient for packaging scripts to analyze the reasons

### DIFF
--- a/ILRepack.IntegrationTests/Scenarios/DotNet462Application/App.config
+++ b/ILRepack.IntegrationTests/Scenarios/DotNet462Application/App.config
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ILRepack.IntegrationTests/Scenarios/DotNet462Application/DotNet462Application.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/DotNet462Application/DotNet462Application.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DotNet462Application</RootNamespace>
     <AssemblyName>DotNet462Application</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/ILRepack.IntegrationTests/Scenarios/DotNet462Application/packages.config
+++ b/ILRepack.IntegrationTests/Scenarios/DotNet462Application/packages.config
@@ -4,5 +4,5 @@
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net462" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net462" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net462" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net462" requireReinstallation="true" />
 </packages>

--- a/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/App.config
+++ b/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/DotNet462NetStandard2.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/DotNet462NetStandard2/DotNet462NetStandard2.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DotNet462NetStandard2</RootNamespace>
     <AssemblyName>DotNet462NetStandard2</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/ILRepack/Application.cs
+++ b/ILRepack/Application.cs
@@ -31,13 +31,13 @@ namespace ILRepacking
             }
             catch (RepackOptions.InvalidTargetKindException e)
             {
-                Console.WriteLine(e.Message);
+                Console.Error.WriteLine(e.Message);
                 Usage();
                 Exit(2);
             }
             catch (Exception e)
             {
-                logger.Log(e);
+                logger.LogError(e);
                 returnCode = 1;
             }
             finally

--- a/ILRepack/ILRepack.csproj
+++ b/ILRepack/ILRepack.csproj
@@ -4,7 +4,7 @@
     <ProjectGuid>{4A253A60-D998-4CA2-B9D5-46567A2FBF80}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>ILRepacking</RootNamespace>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <StartupObject>ILRepacking.Application</StartupObject>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -35,10 +35,10 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data.DataSetExtensions" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ILRepack.snk" />
@@ -51,7 +51,7 @@
   <ItemGroup>
     <PackageReference Include="BamlParser" Version="1.0.0" />
     <PackageReference Include="fasterflect" Version="2.1.3" />
-    <PackageReference Include="Mono.Posix" Version="4.0.0" />
+    <PackageReference Include="Mono.Posix-4.5" Version="4.5.0" />
     <PackageReference Include="SourceLink" Version="1.1.0" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>

--- a/ILRepack/RepackImporter.cs
+++ b/ILRepack/RepackImporter.cs
@@ -682,7 +682,7 @@ namespace ILRepacking
             if (fullName == "<PrivateImplementationDetails>" && type.IsPublic)
                 return true;
 
-            if (_options.AllowedDuplicateTypes.Contains(fullName))
+            if (_options.AllowDuplicateAll || _options.AllowedDuplicateTypes.Contains(fullName))
                 return true;
 
             var top = type;

--- a/ILRepack/RepackLogger.cs
+++ b/ILRepack/RepackLogger.cs
@@ -17,6 +17,13 @@ namespace ILRepacking
             _writer?.WriteLine(logStr);
         }
 
+        public void LogError(object str)
+        {
+            string logStr = str.ToString();
+            Console.Error.WriteLine(logStr);
+            _writer?.WriteLine(logStr);
+        }
+
         public bool Open(string file)
         {
             if (string.IsNullOrEmpty(file))
@@ -36,7 +43,7 @@ namespace ILRepacking
 
         public void Error(string msg)
         {
-            Log($"ERROR: {msg}");
+            LogError($"ERROR: {msg}");
         }
 
         public void Warn(string msg)

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -92,6 +92,10 @@ namespace ILRepacking
         {
             get { return allowedDuplicateTypes; }
         }
+        public bool AllowDuplicateAll
+        {
+            get { return allowDuplicateAll; }
+        }
         public List<string> AllowedDuplicateNameSpaces
         {
             get { return allowedDuplicateNameSpaces; }
@@ -106,6 +110,7 @@ namespace ILRepacking
         private readonly ICommandLine cmd;
         private readonly IFile file;
         private string excludeFile;
+        private bool allowDuplicateAll;
 
         private void AllowDuplicateType(string typeName)
         {
@@ -147,8 +152,13 @@ namespace ILRepacking
         void Parse()
         {
             AllowDuplicateResources = cmd.Modifier("allowduplicateresources");
+            var allowDup = cmd.Modifier("allowdup");
             foreach (string dupType in cmd.Options("allowdup"))
-                AllowDuplicateType(dupType);
+            {
+                if (!string.IsNullOrEmpty(dupType))
+                    AllowDuplicateType(dupType);
+            }
+            allowDuplicateAll = allowedDuplicateTypes.Count == 0 && allowDup;
             AllowMultipleAssemblyLevelAttributes = cmd.Modifier("allowmultiple");
             AllowWildCards = cmd.Modifier("wildcards");
             AllowZeroPeKind = cmd.Modifier("zeropekind");


### PR DESCRIPTION
2、Compatible with ilmerge's allowDup parameter handling (without the class name after it)