### PR TITLE
Replaced BinarySerializer with DataContractSerializer to avoid NotSupportException on .NET 8.0

### DIFF
--- a/ILRepack.IntegrationTests/ILRepack.IntegrationTests.csproj
+++ b/ILRepack.IntegrationTests/ILRepack.IntegrationTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ILRepack.IntegrationTests</RootNamespace>
     <AssemblyName>ILRepack.IntegrationTests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/AnotherClassLibrary.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/AnotherClassLibrary.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AnotherClassLibrary</RootNamespace>
     <AssemblyName>AnotherClassLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/ILRepack.IntegrationTests/Scenarios/ClassLibrary/ClassLibrary.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/ClassLibrary/ClassLibrary.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClassLibrary</RootNamespace>
     <AssemblyName>ClassLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/ILRepack.IntegrationTests/Scenarios/LibraryClassUsageInXAML/LibraryClassUsageInXAML.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/LibraryClassUsageInXAML/LibraryClassUsageInXAML.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LibraryClassUsageInXAML</RootNamespace>
     <AssemblyName>LibraryClassUsageInXAML</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/ILRepack.IntegrationTests/Scenarios/LibraryUserControlUsageInXAML/LibraryUserControlUsageInXAML.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/LibraryUserControlUsageInXAML/LibraryUserControlUsageInXAML.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LibraryUserControlUsageInXAML</RootNamespace>
     <AssemblyName>LibraryUserControlUsageInXAML</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/ILRepack.IntegrationTests/Scenarios/NestedLibraryUsageInXAML/NestedLibraryUsageInXAML.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/NestedLibraryUsageInXAML/NestedLibraryUsageInXAML.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NestedLibraryUsageInXAML</RootNamespace>
     <AssemblyName>NestedLibraryUsageInXAML</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/ILRepack.IntegrationTests/Scenarios/WPFSampleApplication/WPFSampleApplication.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/WPFSampleApplication/WPFSampleApplication.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WPFSampleApplication</RootNamespace>
     <AssemblyName>WPFSampleApplication</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/ILRepack.IntegrationTests/Scenarios/WPFThemingAndLibraryStyles/WPFThemingAndLibraryStyles.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/WPFThemingAndLibraryStyles/WPFThemingAndLibraryStyles.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WPFThemingAndLibraryStyles</RootNamespace>
     <AssemblyName>WPFThemingAndLibraryStyles</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/ILRepack.Tests/ILRepack.Tests.csproj
+++ b/ILRepack.Tests/ILRepack.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ILRepack.Tests</RootNamespace>
     <AssemblyName>ILRepack.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/ILRepack/ILRepack.csproj
+++ b/ILRepack/ILRepack.csproj
@@ -4,7 +4,7 @@
     <ProjectGuid>{4A253A60-D998-4CA2-B9D5-46567A2FBF80}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>ILRepacking</RootNamespace>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <StartupObject>ILRepacking.Application</StartupObject>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>

--- a/ILRepack/Steps/ResourcesRepackStep.cs
+++ b/ILRepack/Steps/ResourcesRepackStep.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Resources;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Runtime.Serialization;
 
 namespace ILRepacking.Steps
 {
@@ -280,7 +280,8 @@ namespace ILRepacking.Steps
 
         private static string[] GetRepackListFromResource(EmbeddedResource resource)
         {
-            return (string[])new BinaryFormatter().Deserialize(resource.GetResourceStream());
+            var reader = new DataContractSerializer(typeof(string[]));
+            return (string[])reader.ReadObject(resource.GetResourceStream());
         }
 
         private static EmbeddedResource GenerateRepackListResource(List<string> repackList)
@@ -288,7 +289,8 @@ namespace ILRepacking.Steps
             repackList.Sort();
             using (var stream = new MemoryStream())
             {
-                new BinaryFormatter().Serialize(stream, repackList.ToArray());
+                var writer = new DataContractSerializer(typeof(string[]));
+                writer.WriteObject(stream, repackList.ToArray());
                 return new EmbeddedResource(ILRepackListResourceName, ManifestResourceAttributes.Public, stream.ToArray());
             }
         }

--- a/ILRepack/app.config
+++ b/ILRepack/app.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0"/>
+    <supportedRuntime version="v4.5"/>
   </startup>
 </configuration>


### PR DESCRIPTION
Issue:
https://github.com/gluck/il-repack/issues/327