### PR TITLE
Don't strong name sign for delay signing

### DIFF
--- a/ILRepack/Steps/SigningStep.cs
+++ b/ILRepack/Steps/SigningStep.cs
@@ -67,9 +67,11 @@ namespace ILRepacking.Steps
                 }
                 _repackContext.TargetAssemblyDefinition.Name.PublicKey = publicKey;
                 _repackContext.TargetAssemblyDefinition.Name.Attributes |= AssemblyAttributes.PublicKey;
-                _repackContext.TargetAssemblyMainModule.Attributes |= ModuleAttributes.StrongNameSigned;
                 if (!_repackOptions.DelaySign)
+                {
+                    _repackContext.TargetAssemblyMainModule.Attributes |= ModuleAttributes.StrongNameSigned;
                     KeyPair = snkp;
+                }
             }
             else
             {


### PR DESCRIPTION
I found this as a major difference from ILMerge that causes some internal issues in our code. The change is to strong name sign the assembly only if it's not Delay Signed - that's ilmerge behavior. I'm pretty sure that should solve this issue https://github.com/gluck/il-repack/issues/290