### PR TITLE
Update Cecil submodule to latest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "cecil"]
 	path = cecil
-	url = https://github.com/gluck/cecil.git
+	url = https://github.com/KirillOsenkov/cecil
+	branch = ilrepack

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,9 @@
 <Project>
 
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>

--- a/ILRepack.IntegrationTests/NuGet/RepackNuGetTests.cs
+++ b/ILRepack.IntegrationTests/NuGet/RepackNuGetTests.cs
@@ -136,7 +136,7 @@ namespace ILRepack.IntegrationTests.NuGet
         {
             // This test requires Mono.Cecil.Pdb.dll. Indicate a dependency such that
             // the reference is not accidentally removed.
-            _ = typeof(Mono.Cecil.Pdb.PdbReader);
+            _ = typeof(Mono.Cecil.Pdb.PdbReaderProvider);
 
             var platform = Platform.From(
                 Package.From("TfsIndexer", "1.2.4"),

--- a/ILRepack.IntegrationTests/NuGet/TestHelpers.cs
+++ b/ILRepack.IntegrationTests/NuGet/TestHelpers.cs
@@ -38,11 +38,19 @@ namespace ILRepack.IntegrationTests.NuGet
 
         private static void ReloadAndCheckReferences(RepackOptions repackOptions)
         {
-            var outputFile = AssemblyDefinition.ReadAssembly(repackOptions.OutputFile, new ReaderParameters(ReadingMode.Immediate));
-            var mergedFiles = repackOptions.ResolveFiles().Select(f => AssemblyDefinition.ReadAssembly(f, new ReaderParameters(ReadingMode.Deferred)));
+            using var ar = new DefaultAssemblyResolver();
+            using var outputFile = AssemblyDefinition.ReadAssembly(repackOptions.OutputFile, new ReaderParameters(ReadingMode.Immediate));
+            var mergedFiles = repackOptions
+                .ResolveFiles()
+                .Select(f => AssemblyDefinition.ReadAssembly(f, new ReaderParameters(ReadingMode.Deferred)))
+                .ToArray();
             foreach (var a in outputFile.MainModule.AssemblyReferences.Where(x => mergedFiles.Any(y => repackOptions.KeepOtherVersionReferences ? x.FullName == y.FullName : x.Name == y.Name.Name)))
             {
                 Assert.Fail($"Merged assembly retains a reference to one (or more) of the merged files: {a.FullName}");
+            }
+            foreach (var a in mergedFiles)
+            {
+                a.Dispose();
             }
         }
 

--- a/ILRepack/IKVMLineIndexer.cs
+++ b/ILRepack/IKVMLineIndexer.cs
@@ -17,7 +17,6 @@ namespace ILRepacking
     {
         private readonly IRepackContext repack;
         private bool enabled;
-        private LineNumberWriter lineNumberWriter;
         private string fileName;
         private TypeReference sourceFileAttributeTypeReference;
         private TypeReference lineNumberTableAttributeTypeReference;
@@ -41,29 +40,29 @@ namespace ILRepacking
 
         public void Reset()
         {
-            lineNumberWriter = null;
             fileName = null;
         }
 
         public void PreMethodBodyRepack(MethodBody body, MethodDefinition parent)
         {
-            if (!enabled)
+            if (!enabled || !parent.DebugInformation.HasSequencePoints)
                 return;
 
             Reset();
             if (!parent.CustomAttributes.Any(x => x.Constructor.DeclaringType.Name == "LineNumberTableAttribute"))
             {
-                lineNumberWriter = new LineNumberWriter(body.Instructions.Count / 4);
+                var lineNumberWriter = new LineNumberWriter(body.Instructions.Count / 4);
+                foreach (var sp in parent.DebugInformation.SequencePoints)
+                {
+                    AddSeqPoint(sp, lineNumberWriter);
+                }
+                PostMethodBodyRepack(parent, lineNumberWriter);
             }
         }
 
-        public void ProcessMethodBodyInstruction(Instruction instr)
+        private void AddSeqPoint(SequencePoint currentSeqPoint, LineNumberWriter lineNumberWriter)
         {
-            if (!enabled)
-                return;
-
-            var currentSeqPoint = instr.SequencePoint;
-            if (lineNumberWriter != null && currentSeqPoint != null)
+            if (currentSeqPoint != null)
             {
                 if (fileName == null && currentSeqPoint.Document != null)
                 {
@@ -84,25 +83,22 @@ namespace ILRepacking
                 {
                     if (lineNumberWriter.LineNo > 0)
                     {
-                        lineNumberWriter.AddMapping(instr.Offset, -1);
+                        lineNumberWriter.AddMapping(currentSeqPoint.Offset, -1);
                     }
                 }
                 else
                 {
                     if (lineNumberWriter.LineNo != currentSeqPoint.StartLine)
                     {
-                        lineNumberWriter.AddMapping(instr.Offset, currentSeqPoint.StartLine);
+                        lineNumberWriter.AddMapping(currentSeqPoint.Offset, currentSeqPoint.StartLine);
                     }
                 }
             }
         }
 
-        public void PostMethodBodyRepack(MethodDefinition parent)
+        private void PostMethodBodyRepack(MethodDefinition parent, LineNumberWriter lineNumberWriter)
         {
-            if (!enabled)
-                return;
-
-            if (lineNumberWriter != null && lineNumberWriter.Count > 0)
+            if (lineNumberWriter.Count > 0)
             {
                 CustomAttribute ca;
                 if (lineNumberWriter.Count == 1)
@@ -155,7 +151,7 @@ namespace ILRepacking
             IMetadataScope ikvmRuntimeReference = repack.TargetAssemblyMainModule.AssemblyReferences.FirstOrDefault(r => r.Name == "IKVM.Runtime");
             if (ikvmRuntimeReference == null)
             {
-                ikvmRuntimeReference = repack.MergeScope(repack.GlobalAssemblyResolver.Resolve("IKVM.Runtime").Name);
+                ikvmRuntimeReference = repack.MergeScope(repack.GlobalAssemblyResolver.Resolve(new AssemblyNameReference("IKVM.Runtime", null)).Name);
             }
             if (ikvmRuntimeReference == null)
             {

--- a/ILRepack/Mixins/Mixins.cs
+++ b/ILRepack/Mixins/Mixins.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Mono.Collections.Generic;
+
+namespace ILRepacking.Mixins
+{
+    static class CollectionMixins
+    {
+        public static void AddRange<T>(this Collection<T> destination, IEnumerable<T> source)
+        {
+            foreach (var item in source)
+            {
+                destination.Add(item);
+            }
+        }
+    }
+}

--- a/ILRepack/PlatformFixer.cs
+++ b/ILRepack/PlatformFixer.cs
@@ -192,7 +192,7 @@ namespace ILRepacking
         private void FixPlatformVersion(GenericParameter gp)
         {
             if (gp.HasConstraints)
-                foreach (TypeReference tr in gp.Constraints)
+                foreach (var tr in gp.Constraints)
                     FixPlatformVersion(tr);
             if (gp.HasCustomAttributes)
                 foreach (CustomAttribute ca in gp.CustomAttributes)
@@ -200,6 +200,11 @@ namespace ILRepacking
             if (gp.HasGenericParameters)
                 foreach (GenericParameter gp1 in gp.GenericParameters)
                     FixPlatformVersion(gp1);
+        }
+
+        private void FixPlatformVersion(GenericParameterConstraint gp)
+        {
+            FixPlatformVersion(gp.ConstraintType);
         }
 
         private void FixPlatformVersion(CustomAttribute ca)

--- a/ILRepack/ReferenceFixator.cs
+++ b/ILRepack/ReferenceFixator.cs
@@ -111,6 +111,15 @@ namespace ILRepacking
                 FixOverridenMethodDef(meth);
         }
 
+        private void FixReferences(Collection<GenericParameterConstraint> constraints)
+        {
+            foreach (var constraint in constraints)
+            {
+                constraint.ConstraintType = Fix(constraint.ConstraintType);
+                FixReferences(constraint.CustomAttributes);
+            }
+        }
+
         internal void FixReferences(TypeDefinition type)
         {
             FixReferences(type.GenericParameters);
@@ -118,7 +127,11 @@ namespace ILRepacking
             type.BaseType = Fix(type.BaseType);
 
             // interfaces before methods, because methods will have to go through them
-            FixReferences(type.Interfaces);
+            foreach (InterfaceImplementation nested in type.Interfaces)
+            {
+                nested.InterfaceType = Fix(nested.InterfaceType);
+                FixReferences(nested.CustomAttributes);
+            }
 
             // nested types first
             foreach (TypeDefinition nested in type.NestedTypes)
@@ -332,7 +345,7 @@ namespace ILRepacking
         {
             if (typeAttribute == null)
                 return false;
-            if (typeAttribute.Interfaces.Any(@interface => @interface.FullName == "java.lang.annotation.Annotation"))
+            if (typeAttribute.Interfaces.Any(@interface => @interface.InterfaceType.FullName == "java.lang.annotation.Annotation"))
                 return true;
             return typeAttribute.BaseType != null && IsAnnotation(typeAttribute.BaseType.Resolve());
         }

--- a/ILRepack/RepackAssemblyResolver.cs
+++ b/ILRepack/RepackAssemblyResolver.cs
@@ -1,16 +1,12 @@
 using Mono.Cecil;
-using System.Collections.Generic;
 
 namespace ILRepacking
 {
     public class RepackAssemblyResolver : DefaultAssemblyResolver
     {
-        public void RegisterAssemblies(IList<AssemblyDefinition> mergedAssemblies)
+        public new void RegisterAssembly(AssemblyDefinition assembly)
         {
-            foreach (var assemblyDefinition in mergedAssemblies)
-            {
-                RegisterAssembly(assemblyDefinition);
-            }
+            base.RegisterAssembly(assembly);
         }
     }
 }

--- a/ILRepack/Steps/SourceServerData/PdbStr.cs
+++ b/ILRepack/Steps/SourceServerData/PdbStr.cs
@@ -19,6 +19,11 @@ namespace ILRepacking.Steps.SourceServerData
 
         public string Read(string pdb)
         {
+            if (!File.Exists(pdb))
+            {
+                return $"File doesn't exist: {pdb}";
+            }
+
             return Execute($"-r -p:{pdb} -s:srcsrv");
         }
 

--- a/ILRepack/Steps/XamlResourcePathPatcherStep.cs
+++ b/ILRepack/Steps/XamlResourcePathPatcherStep.cs
@@ -69,7 +69,7 @@ namespace ILRepacking.Steps
 
         private void PatchIComponentConnector(TypeDefinition type)
         {
-            if (!type.Interfaces.Any(t => t.FullName == "System.Windows.Markup.IComponentConnector"))
+            if (!type.Interfaces.Any(t => t.InterfaceType.FullName == "System.Windows.Markup.IComponentConnector"))
                 return;
 
             var initializeMethod = type.Methods.FirstOrDefault(m =>


### PR DESCRIPTION
Use cecil from https://github.com/KirillOsenkov/cecil/tree/ilrepack

Read embedded pdbs

Copy debug information for scopes and imports
Taken from https://github.com/Alexx999/il-repack/pull/3

Make the output assembly MVID deterministic

Fix test locking dlls
Add .ToArray() to flush the Linq expression so that it is not evaluated more than once.

Better error if the pdb doesn't exist