### PR TITLE
include missing arg in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Syntax: ILRepack.exe [options] /out:<path> <path_to_primary> [<other_assemblies>
  - /internalize[:<excludefile>]  sets all types but the ones from the first assembly 'internal'. <excludefile> contains one regex per
                                  line to compare against FullName of types NOT to internalize.
  - /renameInternalized  rename all internalized types
+ - /excludeinternalizeserializable do not internalize types marked as Serializable
  - /delaysign           sets the key, but don't sign the assembly
  - /usefullpublickeyforreferences - NOT IMPLEMENTED
  - /align               - NOT IMPLEMENTED


### PR DESCRIPTION
I was confused why I couldn't find the option that @KirillOsenkov was talking about - it was not in the README.md! 🙂