### PR TITLE
Provide a dotnet global tool version of ilrepack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           dotnet tool install -g --version 4.0.18 sleet 
           sleet push bin --config none -f --verbose -p "SLEET_FEED_CONTAINER=nuget" -p "SLEET_FEED_CONNECTIONSTRING=${{ secrets.SLEET_CONNECTION }}" -p "SLEET_FEED_TYPE=azure" || echo "No packages found"
   
-  test:
+  test-tool:
     name: test-${{ matrix.os }}
     needs: build
     runs-on: ${{ matrix.os }}
@@ -88,6 +88,9 @@ jobs:
       matrix:
         os: [ 'windows-latest', 'ubuntu-latest', 'macOS-latest' ]
     steps:
+      - name: 🤘 checkout
+        uses: actions/checkout@v4
+
       - name: ⬇️ artifacts
         uses: actions/download-artifact@v3
         with:
@@ -100,9 +103,27 @@ jobs:
 
       - name: 🧪 run
         run: |
-          ilrepack /help
-          if [ $? -eq 2 ]; then
-              echo "Done"
-          else
-              exit 1
-          fi
+          ilrepack --version
+
+      - name: 📦 ilrepack
+        shell: pwsh
+        working-directory: ILRepack.IntegrationTests/Scenarios/AnalyzerWithDependencies
+        run: |
+          dotnet build -c:Release -p:MergeAnalyzerAssemblies=false
+          test-path bin/Release/netstandard2.0/Microsoft.IdentityModel.Abstractions.dll | Should -Be $true
+          test-path bin/Release/netstandard2.0/Microsoft.IdentityModel.JsonWebTokens.dll | Should -Be $true
+          test-path bin/Release/netstandard2.0/Microsoft.IdentityModel.Logging.dll | Should -Be $true
+          test-path bin/Release/netstandard2.0/Microsoft.IdentityModel.Tokens.dll | Should -Be $true
+          test-path bin/Release/netstandard2.0/System.Text.Encoding.CodePages.dll | Should -Be $true
+          test-path bin/Release/netstandard2.0/System.Text.Encodings.Web.dll | Should -Be $true
+          test-path bin/Release/netstandard2.0/System.Text.Json.dll | Should -Be $true
+          # ensure the same assemblies are not present when ilrepack global tool is run
+          dotnet build -c:Release -p:MergeAnalyzerAssemblies=true
+          test-path bin/Release/netstandard2.0/Microsoft.IdentityModel.Abstractions.dll | Should -Be $false
+          test-path bin/Release/netstandard2.0/Microsoft.IdentityModel.JsonWebTokens.dll | Should -Be $false
+          test-path bin/Release/netstandard2.0/Microsoft.IdentityModel.Logging.dll | Should -Be $false
+          test-path bin/Release/netstandard2.0/Microsoft.IdentityModel.Tokens.dll | Should -Be $false
+          test-path bin/Release/netstandard2.0/System.Text.Encoding.CodePages.dll | Should -Be $false
+          test-path bin/Release/netstandard2.0/System.Text.Encodings.Web.dll | Should -Be $false
+          test-path bin/Release/netstandard2.0/System.Text.Json.dll | Should -Be $false
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,9 @@ jobs:
     name: test-${{ matrix.os }}
     needs: build
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: pwsh
     strategy:
       matrix:
         os: [ 'windows-latest', 'ubuntu-latest', 'macOS-latest' ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,105 @@
+﻿# Builds and runs tests in all three supported OSes
+# Pushes CI feed if secrets.SLEET_CONNECTION is provided
+
+name: build
+on: 
+  workflow_dispatch:
+  push:
+    branches: [ main, dev, 'dev/*', 'feature/*', 'rel/*' ]
+    paths-ignore:
+      - changelog.md
+      - code-of-conduct.md
+      - security.md
+      - support.md
+      - readme.md
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+env:
+  DOTNET_NOLOGO: true
+  Configuration: Release
+  PackageOutputPath: ${{ github.workspace }}/bin
+  VersionPrefix: 42.42.${{ github.run_number }}
+  VersionLabel: ${{ github.ref }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: "windows-latest"
+    steps:
+      - name: 🤘 checkout
+        uses: actions/checkout@v4
+        with: 
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: ⚙ msbuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: 🙏 build
+        shell: pwsh
+        run: msbuild /r /m /bl 
+
+      - name: 🧪 test
+        run: dotnet test --no-build -l trx
+
+      - name: 🗎 trx
+        if: always()
+        run: |
+            dotnet tool install -g dotnet-trx
+            trx
+
+      - name: 📦 pack
+        run: dotnet pack --no-build ILRepackTool/ILRepackTool.csproj
+
+      - name: ⬆️ upload
+        if: success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: pkg
+          path: bin/*   
+
+      - name: 🐛 logs
+        uses: actions/upload-artifact@v3
+        if: runner.debug && always()
+        with:
+          name: logs
+          path: '*.binlog'
+
+      - name: 🚀 sleet
+        env:
+          SLEET_CONNECTION: ${{ secrets.SLEET_CONNECTION }}
+        if: env.SLEET_CONNECTION != ''
+        run: |
+          dotnet tool install -g --version 4.0.18 sleet 
+          sleet push bin --config none -f --verbose -p "SLEET_FEED_CONTAINER=nuget" -p "SLEET_FEED_CONNECTIONSTRING=${{ secrets.SLEET_CONNECTION }}" -p "SLEET_FEED_TYPE=azure" || echo "No packages found"
+  
+  test:
+    name: test-${{ matrix.os }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ 'windows-latest', 'ubuntu-latest', 'macOS-latest' ]
+    steps:
+      - name: ⬇️ artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: pkg
+          path: bin
+
+      - name: ⚙ install
+        working-directory: bin
+        run: dotnet tool update -g dotnet-ilrepack --prerelease --add-source .
+
+      - name: 🧪 run
+        run: |
+          ilrepack /help
+          if [ $? -eq 2 ]; then
+              echo "Done"
+          else
+              exit 1
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,9 @@ jobs:
             trx
 
       - name: 📦 pack
-        run: dotnet pack --no-build ILRepackTool/ILRepackTool.csproj
+        run: |
+            dotnet pack --no-build ILRepack/ILRepack.csproj
+            dotnet pack --no-build ILRepackTool/ILRepackTool.csproj
 
       - name: ⬆️ upload
         if: success()
@@ -71,7 +73,7 @@ jobs:
 
       - name: 🚀 sleet
         env:
-          SLEET_CONNECTION: ${{ secrets.SLEET_CONNECTION }}
+            SLEET_CONNECTION: ${{ secrets.SLEET_CONNECTION }}
         if: env.SLEET_CONNECTION != ''
         run: |
           dotnet tool install -g --version 4.0.18 sleet 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+﻿# Builds a final release version and pushes to nuget.org 
+# whenever a release is published.
+# Requires: secrets.NUGET_API_KEY
+
+name: publish
+on:
+  release:
+    types: [prereleased, released]
+
+env:
+  DOTNET_NOLOGO: true
+  Configuration: Release
+  PackageOutputPath: ${{ github.workspace }}/bin
+  GeneratePackageOnBuild: true
+  VersionLabel: ${{ github.ref }}
+  
+jobs:
+  publish:
+    runs-on: "windows-latest"
+    steps:
+      - name: 🤘 checkout
+        uses: actions/checkout@v4
+        with: 
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: 🙏 build
+        run: dotnet build
+
+      - name: ⚙ install
+        run: dotnet tool install -g dotnet-ilrepack --add-source ./bin
+
+      - name: 🧪 test
+        run: dotnet test --no-build -l trx
+
+      - name: 🗎 trx
+        if: always()
+        run: |
+            dotnet tool install -g dotnet-trx
+            trx
+
+      - name: 🚀 nuget
+        run: dotnet nuget push ./bin/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,11 @@ env:
   DOTNET_NOLOGO: true
   Configuration: Release
   PackageOutputPath: ${{ github.workspace }}/bin
-  GeneratePackageOnBuild: true
   VersionLabel: ${{ github.ref }}
   
 jobs:
   publish:
-    runs-on: "windows-latest"
+    runs-on: windows-latest
     steps:
       - name: 🤘 checkout
         uses: actions/checkout@v4
@@ -24,11 +23,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: 🙏 build
-        run: dotnet build
+      - name: ⚙ msbuild
+        uses: microsoft/setup-msbuild@v2
 
-      - name: ⚙ install
-        run: dotnet tool install -g dotnet-ilrepack --add-source ./bin
+      - name: 🙏 build
+        run: msbuild /r /m /bl 
 
       - name: 🧪 test
         run: dotnet test --no-build -l trx
@@ -39,5 +38,13 @@ jobs:
             dotnet tool install -g dotnet-trx
             trx
 
+      - name: 📦 pack
+        run: |
+            dotnet pack --no-build ILRepack/ILRepack.csproj
+            dotnet pack --no-build ILRepackTool/ILRepackTool.csproj
+
       - name: 🚀 nuget
-        run: dotnet nuget push ./bin/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} --skip-duplicate
+        env:
+            NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        if: env.NUGET_API_KEY  != ''
+        run: dotnet nuget push ./bin/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,6 @@ _NCrunch*
 *.ncrunchproject
 *.sln.cache
 *.DotSettings
-/.vs
+.vs
 /.idea
 *.binlog

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,4 +15,27 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
 
+  <PropertyGroup Label="Version">
+    <VersionPrefix Condition="$(VersionPrefix) == ''">42.42.42</VersionPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Version" Condition="$(VersionLabel) != ''">
+    <_VersionLabel>$(VersionLabel.Replace('refs/heads/', ''))</_VersionLabel>
+    <_VersionLabel>$(_VersionLabel.Replace('refs/tags/v', ''))</_VersionLabel>
+
+    <!-- For PRs, we just need a fixed package version numbered after the PR # itself, so remove the commits # at the end -->
+    <_VersionLabel Condition="$(_VersionLabel.Contains('refs/pull/'))">$(VersionLabel.TrimEnd('.0123456789'))</_VersionLabel>
+    <!-- Next replace the prefix for simply 'pr', so we end up with 'pr99/merge' by default -->
+    <_VersionLabel>$(_VersionLabel.Replace('refs/pull/', 'pr'))</_VersionLabel>
+    <!-- Remove the /merge now, if present -->
+    <_VersionLabel>$(_VersionLabel.Replace('/merge', ''))</_VersionLabel>
+    <!-- Finally sanitize the branch with dashes, so we can build path-separated branches, like rel/v1.0.0 or feature/foo -->
+    <_VersionLabel>$(_VersionLabel.Replace('/', '-'))</_VersionLabel>
+
+    <!-- Set sanitized version to the actual version suffix used in build/pack -->
+    <VersionSuffix Condition="!$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</VersionSuffix>
+    <!-- Special case for tags, the label is actually the version. Backs compat since passed-in value overrides MSBuild-set one -->
+    <Version Condition="$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</Version>
+  </PropertyGroup>
+
 </Project>

--- a/ILRepack.IntegrationTests/ILRepack.IntegrationTests.csproj
+++ b/ILRepack.IntegrationTests/ILRepack.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DebugType>embedded</DebugType>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
   </PropertyGroup>
@@ -26,13 +26,14 @@
     <ProjectReference Include="..\ILRepack\ILRepack.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="fasterflect" Version="2.1.3" />
-    <PackageReference Include="FSharp.Core" Version="4.0.0.1" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3"/>
-    <PackageReference Include="Moq" Version="4.2.1409.1722" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="Rx-Main" Version="2.2.5" />
+    <PackageReference Include="fasterflect" Version="3.0.0" />
+    <PackageReference Include="FSharp.Core" Version="8.0.300" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="SourceLink" Version="1.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/ILRepack.IntegrationTests/Scenarios/AnalyzerWithDependencies/AnalyzerWithDependencies.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/AnalyzerWithDependencies/AnalyzerWithDependencies.csproj
@@ -1,0 +1,68 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <MergeAnalyzerAssemblies Condition="$(Configuration) == 'Release'">true</MergeAnalyzerAssemblies>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.6.2" />
+  </ItemGroup>
+
+  <Target Name="ILRepack" AfterTargets="CoreCompile" BeforeTargets="CopyFilesToOutputDirectory"
+          Inputs="@(IntermediateAssembly -&gt; '%(FullPath)')"
+          Outputs="$(IntermediateOutputPath)ilrepack.txt"
+          Returns="@(MergedAssemblies)"
+          Condition="Exists(@(IntermediateAssembly -&gt; '%(FullPath)')) And '$(MergeAnalyzerAssemblies)' == 'true'">
+    <ItemGroup>
+      <ReferenceCopyLocalAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll' 
+        And !$([MSBuild]::ValueOrDefault('%(FileName)', '').EndsWith('.resources', StringComparison.OrdinalIgnoreCase))" />
+      <MergedAssemblies Include="@(ReferenceCopyLocalAssemblies)" Condition="
+        !$([MSBuild]::ValueOrDefault('%(FileName)', '').StartsWith('Microsoft.CodeAnalysis', StringComparison.OrdinalIgnoreCase)) And
+        !$([MSBuild]::ValueOrDefault('%(FileName)', '').StartsWith('Microsoft.CSharp', StringComparison.OrdinalIgnoreCase)) And
+        !$([MSBuild]::ValueOrDefault('%(FileName)', '').StartsWith('System.', StringComparison.OrdinalIgnoreCase))"
+      />
+      <!-- Brings in System/Microsoft.IdentityModel, System.Text.Encodings.Web, System.Text.Json  -->
+      <MergedAssemblies Include="@(ReferenceCopyLocalAssemblies)" Condition="
+        $([MSBuild]::ValueOrDefault('%(FileName)', '').StartsWith('System.IdentityModel', StringComparison.OrdinalIgnoreCase)) Or
+        $([MSBuild]::ValueOrDefault('%(FileName)', '').StartsWith('Microsoft.IdentityModel', StringComparison.OrdinalIgnoreCase)) Or
+        $([MSBuild]::ValueOrDefault('%(FileName)', '').StartsWith('System.Text', StringComparison.OrdinalIgnoreCase))"
+      />
+    </ItemGroup>
+    <ItemGroup>
+      <ReferenceCopyLocalDirs Include="@(ReferenceCopyLocalPaths -&gt; '%(RootDir)%(Directory)')" />
+      <ReferenceCopyLocalPaths Remove="@(MergedAssemblies)" />
+      <LibDir Include="@(ReferenceCopyLocalDirs -&gt; Distinct())" />
+    </ItemGroup>
+    <PropertyGroup>
+      <AbsoluteAssemblyOriginatorKeyFile Condition="'$(AssemblyOriginatorKeyFile)' != ''">$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(MSBuildProjectDirectory)','$(AssemblyOriginatorKeyFile)'))))</AbsoluteAssemblyOriginatorKeyFile>
+      <ILRepackArgs Condition="'$(AbsoluteAssemblyOriginatorKeyFile)' != ''">/keyfile:"$(AbsoluteAssemblyOriginatorKeyFile)" /delaysign</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) /internalize</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) /union</ILRepackArgs>
+      <!-- This is needed to merge types with identical names into one, wich happens with IFluentInterface in Merq and Merq.Core (Xamarin.Messaging dependencies) -->
+      <ILRepackArgs>$(ILRepackArgs) @(LibDir -&gt; '/lib:"%(Identity)."', ' ')</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) /out:"@(IntermediateAssembly -&gt; '%(FullPath)')"</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) "@(IntermediateAssembly -&gt; '%(FullPath)')"</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) @(MergedAssemblies -&gt; '"%(FullPath)"', ' ')</ILRepackArgs>
+    </PropertyGroup>
+    
+    <!-- Run dotnet global tool version of ilrepack -->
+    <Exec Command='ilrepack $(ILRepackArgs)' WorkingDirectory="$(MSBuildProjectDirectory)\$(OutputPath)" StandardErrorImportance="high" IgnoreStandardErrorWarningFormat="true" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
+    </Exec>
+    <Message Importance="high" Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0'" />
+    <Delete Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' != '0'" />
+    <Touch AlwaysCreate="true" Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' == '0'" />
+    <Error Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0' And '$(ContinueOnError)' != 'true'" />
+    <ItemGroup>
+      <MergedAssembliesToRemove Include="@(MergedAssemblies)" />
+      <MergedAssembliesToRemove Remove="@(ReferenceToPreserve)" />
+    </ItemGroup>
+    <Delete Files="@(MergedAssembliesToRemove -&gt; '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
+  </Target>
+
+</Project>

--- a/ILRepack.IntegrationTests/Scenarios/AnalyzerWithDependencies/SampleAnalyzer.cs
+++ b/ILRepack.IntegrationTests/Scenarios/AnalyzerWithDependencies/SampleAnalyzer.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.IdentityModel.JsonWebTokens;
+
+namespace AnalyzerWithDependencies;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class SampleAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [
+        new DiagnosticDescriptor("AWD001", "Sample analyzer", "Hello {0}", "Design", DiagnosticSeverity.Warning, isEnabledByDefault: true)];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationAction(ctx =>
+        {
+            var compilation = ctx.Compilation;
+            // Exercise some external dependency
+            var token = new JsonWebToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+            var name = token.GetPayloadValue<string>("name");   
+            var diagnostic = Diagnostic.Create(SupportedDiagnostics[0], Location.None, name);
+            ctx.ReportDiagnostic(diagnostic);
+        });
+    }
+}

--- a/ILRepack.IntegrationTests/Scenarios/AnalyzerWithDependencies/readme.md
+++ b/ILRepack.IntegrationTests/Scenarios/AnalyzerWithDependencies/readme.md
@@ -1,0 +1,3 @@
+Exercises the dotnet-ilrepack tool instead of the ilrepack.exe
+
+Requires the dotnet-ilrepack tool to be installed. Before compiling.

--- a/ILRepack.Tests/ILRepack.Tests.csproj
+++ b/ILRepack.Tests/ILRepack.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DebugType>embedded</DebugType>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>

--- a/ILRepack.Tests/ILRepack.Tests.csproj
+++ b/ILRepack.Tests/ILRepack.Tests.csproj
@@ -1,21 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <DebugType>embedded</DebugType>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <UseWPF>true</UseWPF>
+    <EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandLineTests.cs" />
     <Compile Include="MiscTests.cs" />
@@ -32,7 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\cecil\Mono.Cecil.csproj" />
-    <ProjectReference Include="..\ILRepack.IntegrationTests\Scenarios\ClassLibrary\ClassLibrary.csproj" />
+    <ProjectReference Include="..\ILRepack.IntegrationTests\Scenarios\ClassLibrary\ClassLibrary.csproj" Condition="'$(OS)' == 'Windows_NT'" />
     <ProjectReference Include="..\ILRepack\ILRepack.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -62,8 +52,8 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="fasterflect" Version="2.1.3" />
-    <PackageReference Include="Moq" Version="4.2.1409.1722" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="fasterflect" Version="3.0.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
   </ItemGroup>
 </Project>

--- a/ILRepack.Tests/Steps/ResourceProcessing/StringArrayBinaryFormatterTests.cs
+++ b/ILRepack.Tests/Steps/ResourceProcessing/StringArrayBinaryFormatterTests.cs
@@ -32,7 +32,9 @@ namespace ILRepack.Tests.Steps.ResourceProcessing
                 Assert.True(Enumerable.SequenceEqual(stringArray, back));
 
                 var stream = new MemoryStream();
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
                 new BinaryFormatter().Serialize(stream, stringArray);
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
                 var oracleBytes = stream.ToArray();
 
                 Assert.True(Enumerable.SequenceEqual(bytes, oracleBytes));

--- a/ILRepack.sln
+++ b/ILRepack.sln
@@ -1,50 +1,58 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35005.142
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4547EE79-6D49-4318-B473-B5BBF73B434C}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
-		ILRepack.nuspec = ILRepack.nuspec
 		ILRepack.Lib.nuspec = ILRepack.Lib.nuspec
+		ILRepack.nuspec = ILRepack.nuspec
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILRepack", "ILRepack\ILRepack.csproj", "{4A253A60-D998-4CA2-B9D5-46567A2FBF80}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILRepack", "ILRepack\ILRepack.csproj", "{4A253A60-D998-4CA2-B9D5-46567A2FBF80}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Cecil", "cecil\Mono.Cecil.csproj", "{D68133BD-1E63-496E-9EDE-4FBDBF77B486}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILRepack.Tests", "ILRepack.Tests\ILRepack.Tests.csproj", "{468ED600-2E3B-471C-BB8A-B0D968FD7FA2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILRepack.Tests", "ILRepack.Tests\ILRepack.Tests.csproj", "{468ED600-2E3B-471C-BB8A-B0D968FD7FA2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration Tests Scenarios", "Integration Tests Scenarios", "{04819B25-ABEA-46F7-90D5-149C8304F67F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary", "ILRepack.IntegrationTests\Scenarios\ClassLibrary\ClassLibrary.csproj", "{801489B7-46CB-42D0-8581-0120F3566A8F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClassLibrary", "ILRepack.IntegrationTests\Scenarios\ClassLibrary\ClassLibrary.csproj", "{801489B7-46CB-42D0-8581-0120F3566A8F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibraryClassUsageInXAML", "ILRepack.IntegrationTests\Scenarios\LibraryClassUsageInXAML\LibraryClassUsageInXAML.csproj", "{CE27F333-D875-43D0-9D3C-4F8F102FC92D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibraryClassUsageInXAML", "ILRepack.IntegrationTests\Scenarios\LibraryClassUsageInXAML\LibraryClassUsageInXAML.csproj", "{CE27F333-D875-43D0-9D3C-4F8F102FC92D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILRepack.IntegrationTests", "ILRepack.IntegrationTests\ILRepack.IntegrationTests.csproj", "{B0E4D418-5F5D-4F19-B1DB-0659F17F9251}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILRepack.IntegrationTests", "ILRepack.IntegrationTests\ILRepack.IntegrationTests.csproj", "{B0E4D418-5F5D-4F19-B1DB-0659F17F9251}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibraryUserControlUsageInXAML", "ILRepack.IntegrationTests\Scenarios\LibraryUserControlUsageInXAML\LibraryUserControlUsageInXAML.csproj", "{2D4C999E-8175-4505-AC33-7A641ED32F2B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibraryUserControlUsageInXAML", "ILRepack.IntegrationTests\Scenarios\LibraryUserControlUsageInXAML\LibraryUserControlUsageInXAML.csproj", "{2D4C999E-8175-4505-AC33-7A641ED32F2B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AnotherClassLibrary", "ILRepack.IntegrationTests\Scenarios\AnotherClassLibrary\AnotherClassLibrary.csproj", "{F92CF620-F1A5-4A3E-A774-4199F54FEF2E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AnotherClassLibrary", "ILRepack.IntegrationTests\Scenarios\AnotherClassLibrary\AnotherClassLibrary.csproj", "{F92CF620-F1A5-4A3E-A774-4199F54FEF2E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NestedLibraryUsageInXAML", "ILRepack.IntegrationTests\Scenarios\NestedLibraryUsageInXAML\NestedLibraryUsageInXAML.csproj", "{B8282E50-564D-4E5B-B96F-4A8E53067551}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NestedLibraryUsageInXAML", "ILRepack.IntegrationTests\Scenarios\NestedLibraryUsageInXAML\NestedLibraryUsageInXAML.csproj", "{B8282E50-564D-4E5B-B96F-4A8E53067551}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WPFSampleApplication", "ILRepack.IntegrationTests\Scenarios\WPFSampleApplication\WPFSampleApplication.csproj", "{A183949D-1057-4585-B76D-F86CA28C69D0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WPFSampleApplication", "ILRepack.IntegrationTests\Scenarios\WPFSampleApplication\WPFSampleApplication.csproj", "{A183949D-1057-4585-B76D-F86CA28C69D0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WPFThemingAndLibraryStyles", "ILRepack.IntegrationTests\Scenarios\WPFThemingAndLibraryStyles\WPFThemingAndLibraryStyles.csproj", "{6A827942-BEEF-4E49-A3A4-306E21428E85}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WPFThemingAndLibraryStyles", "ILRepack.IntegrationTests\Scenarios\WPFThemingAndLibraryStyles\WPFThemingAndLibraryStyles.csproj", "{6A827942-BEEF-4E49-A3A4-306E21428E85}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNet462Application", "ILRepack.IntegrationTests\Scenarios\DotNet462Application\DotNet462Application.csproj", "{EECC6459-78C6-4A08-9039-DE37E75866E6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNet462Application", "ILRepack.IntegrationTests\Scenarios\DotNet462Application\DotNet462Application.csproj", "{EECC6459-78C6-4A08-9039-DE37E75866E6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNet462NetStandard2", "ILRepack.IntegrationTests\Scenarios\DotNet462NetStandard2\DotNet462NetStandard2.csproj", "{90F1C943-3C23-4091-B07F-0B34748AE056}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNet462NetStandard2", "ILRepack.IntegrationTests\Scenarios\DotNet462NetStandard2\DotNet462NetStandard2.csproj", "{90F1C943-3C23-4091-B07F-0B34748AE056}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibraryCore", "ILRepack.IntegrationTests\Scenarios\ClassLibraryCore\ClassLibraryCore.csproj", "{9B574C47-951F-EB28-A009-53262C44F743}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClassLibraryCore", "ILRepack.IntegrationTests\Scenarios\ClassLibraryCore\ClassLibraryCore.csproj", "{9B574C47-951F-EB28-A009-53262C44F743}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsFormsTestNetCoreApp", "ILRepack.IntegrationTests\Scenarios\WindowsFormsTestNetCoreApp\WindowsFormsTestNetCoreApp.csproj", "{B1C3FCA3-8DDD-CFC0-0B0B-A4BBE31D7E13}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsFormsTestNetCoreApp", "ILRepack.IntegrationTests\Scenarios\WindowsFormsTestNetCoreApp\WindowsFormsTestNetCoreApp.csproj", "{B1C3FCA3-8DDD-CFC0-0B0B-A4BBE31D7E13}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WPFSampleApplicationCore", "ILRepack.IntegrationTests\Scenarios\WPFSampleApplicationCore\WPFSampleApplicationCore.csproj", "{7B3B8608-1E8D-5830-1D03-E2ABB5C782DE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WPFSampleApplicationCore", "ILRepack.IntegrationTests\Scenarios\WPFSampleApplicationCore\WPFSampleApplicationCore.csproj", "{7B3B8608-1E8D-5830-1D03-E2ABB5C782DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILRepackTool", "ILRepackTool\ILRepackTool.csproj", "{B8A1DD9C-70E8-4734-9A26-D593BD406820}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.Cecil.Mdb", "cecil\symbols\mdb\Mono.Cecil.Mdb.csproj", "{13529DEB-9921-4FD0-B50D-F202B9500F53}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.Cecil.Pdb", "cecil\symbols\pdb\Mono.Cecil.Pdb.csproj", "{2FD46DD0-A43E-4DFC-AE1F-E587141FC227}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Cecil", "Cecil", "{3C913262-6FDC-43C2-9BC5-054A4016FE2E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -116,11 +124,24 @@ Global
 		{7B3B8608-1E8D-5830-1D03-E2ABB5C782DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7B3B8608-1E8D-5830-1D03-E2ABB5C782DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7B3B8608-1E8D-5830-1D03-E2ABB5C782DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8A1DD9C-70E8-4734-9A26-D593BD406820}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8A1DD9C-70E8-4734-9A26-D593BD406820}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8A1DD9C-70E8-4734-9A26-D593BD406820}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8A1DD9C-70E8-4734-9A26-D593BD406820}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13529DEB-9921-4FD0-B50D-F202B9500F53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13529DEB-9921-4FD0-B50D-F202B9500F53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13529DEB-9921-4FD0-B50D-F202B9500F53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13529DEB-9921-4FD0-B50D-F202B9500F53}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FD46DD0-A43E-4DFC-AE1F-E587141FC227}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FD46DD0-A43E-4DFC-AE1F-E587141FC227}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FD46DD0-A43E-4DFC-AE1F-E587141FC227}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FD46DD0-A43E-4DFC-AE1F-E587141FC227}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{D68133BD-1E63-496E-9EDE-4FBDBF77B486} = {3C913262-6FDC-43C2-9BC5-054A4016FE2E}
 		{801489B7-46CB-42D0-8581-0120F3566A8F} = {04819B25-ABEA-46F7-90D5-149C8304F67F}
 		{CE27F333-D875-43D0-9D3C-4F8F102FC92D} = {04819B25-ABEA-46F7-90D5-149C8304F67F}
 		{2D4C999E-8175-4505-AC33-7A641ED32F2B} = {04819B25-ABEA-46F7-90D5-149C8304F67F}
@@ -133,6 +154,8 @@ Global
 		{9B574C47-951F-EB28-A009-53262C44F743} = {04819B25-ABEA-46F7-90D5-149C8304F67F}
 		{B1C3FCA3-8DDD-CFC0-0B0B-A4BBE31D7E13} = {04819B25-ABEA-46F7-90D5-149C8304F67F}
 		{7B3B8608-1E8D-5830-1D03-E2ABB5C782DE} = {04819B25-ABEA-46F7-90D5-149C8304F67F}
+		{13529DEB-9921-4FD0-B50D-F202B9500F53} = {3C913262-6FDC-43C2-9BC5-054A4016FE2E}
+		{2FD46DD0-A43E-4DFC-AE1F-E587141FC227} = {3C913262-6FDC-43C2-9BC5-054A4016FE2E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {54C7CB02-6231-428F-BBD0-113CC9852908}

--- a/ILRepack/Application.cs
+++ b/ILRepack/Application.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using ILRepacking.Steps;
 using Mono.Cecil;
@@ -11,6 +12,12 @@ namespace ILRepacking
         [STAThread]
         static int Main(string[] args)
         {
+            if (args.Contains("--version"))
+            {
+                Console.WriteLine(typeof(Application).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion);
+                return 0;
+            }
+
             RepackLogger logger = new RepackLogger();
             RepackOptions options = null;
             int returnCode = -1;

--- a/ILRepack/RepackOptions.cs
+++ b/ILRepack/RepackOptions.cs
@@ -285,7 +285,8 @@ namespace ILRepacking
                     RepackDropAttribute = "RepackDropAttribute";
                 }
 
-                RepackDropAttributes.UnionWith(RepackDropAttribute.Split([';'], StringSplitOptions.RemoveEmptyEntries));
+                // Disambiguate overload for .net8 between string? and [char].
+                RepackDropAttributes.UnionWith(RepackDropAttribute.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
             }
 
             // everything that doesn't start with a '/' must be a file to merge (verify when loading the files)

--- a/ILRepackTool/ILRepackTool.csproj
+++ b/ILRepackTool/ILRepackTool.csproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>ilrepack</ToolCommandName>
+    <PackageId>dotnet-ilrepack</PackageId>
+    <Description>ILRepack - Open-source alternative to ILMerge</Description>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageReadme>readme.md</PackageReadme>
+    <Copyright>Copyright Francois Valdy 2011-2015</Copyright>
+    <PackageTags>ILRepack ILMerge dotnet IL dotnet-tool tool</PackageTags>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/gluck/il-repack</PackageProjectUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ILRepack\**\*.cs" Exclude="..\ILRepack\Properties\AssemblyInfo.cs;..\ILRepack\bin\**\*.*;..\ILRepack\obj\**\*.*;" />
+    <None Include="..\README.md" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="readme.md" />
+    <None Include="..\ilrepack.png" Pack="true" PackagePath="icon.png" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\cecil\Mono.Cecil.csproj" />
+    <ProjectReference Include="..\cecil\symbols\mdb\Mono.Cecil.Mdb.csproj" />
+    <ProjectReference Include="..\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="BamlParser" Version="1.0.1" />
+    <PackageReference Include="fasterflect" Version="3.0.0" />
+    <PackageReference Include="SourceLink" Version="1.1.0" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="$(PkgSourceLink)\tools\pdbstr.exe" LogicalName="ILRepacking.pdbstr.exe" />
+  </ItemGroup>
+
+
+</Project>

--- a/ILRepackTool/ILRepackTool.csproj
+++ b/ILRepackTool/ILRepackTool.csproj
@@ -37,5 +37,4 @@
     <EmbeddedResource Include="$(PkgSourceLink)\tools\pdbstr.exe" LogicalName="ILRepacking.pdbstr.exe" />
   </ItemGroup>
 
-
 </Project>


### PR DESCRIPTION
A dotnet global tool of ilrepack would be much easier to install and use in a cross-platform manner. 

This PR provides:
* As-is repackaging of the main executable tool as a dotnet global tool project
* Build and publish (release) workflows that build, test, pack and publish both the original package and the dotnet-tool
* Cross-platform sanity check test for the packaged tool (extensive unit and integration tests aren't strictly necessary since they already run for the main tool and there's no additional code in the dotnet-tool).

The workflows automatically detect and use two repository/org secrets:
* `SLEET_CONNECTION`: an optional [Sleet](https://github.com/emgarten/Sleet) connection string to provide a CI feed for dogfooding
* `NUGET_API_KEY` to push both the original package and the dotnet-tool to nuget.org when a release (or prerelease) is created.

An example run of the build workflow can be seen in action at https://github.com/kzu/il-repack/actions/runs/9846710011.
And the published CI package for the global tool can be installed with:

```shell
dotnet tool install -g dotnet-ilrepack --prerelease --add-source https://kzu.blob.core.windows.net/nuget/index.json
```

And checked with: `ilrepack --version`.