### PR TITLE
If the renamed type already exists, use a random name.

### DIFF
--- a/ILRepack/RepackImporter.cs
+++ b/ILRepack/RepackImporter.cs
@@ -169,6 +169,15 @@ namespace ILRepacking
                 // rename the type previously imported.
                 // renaming the new one before import made Cecil throw an exception.
                 string other = GenerateName(nt, originalModule?.Mvid.ToString());
+
+                //Check whether renamed type already exists
+                TypeDefinition otherNt = _repackContext.TargetAssemblyMainModule.GetType(other);
+                if (otherNt != null)
+                {
+                    //Create a random name
+                    other = GenerateName(nt);
+                }
+
                 _logger.Verbose("Renaming " + nt.FullName + " into " + other);
                 nt.Name = other;
                 nt = CreateType(type, col, internalize, null);


### PR DESCRIPTION
If the target type already exists after renaming, the same type will exist several times in the assembly.