### PR TITLE
#312: Preserve module initializers

### DIFF
--- a/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/AnotherClassLibrary.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/AnotherClassLibrary.csproj
@@ -23,6 +23,9 @@
     <Compile Include="ADummyUserControl.xaml.cs">
       <DependentUpon>ADummyUserControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ModuleInitializers\MakeInitialized.cs" />
+    <Compile Include="ModuleInitializers\LibraryModuleInitializer.cs" />
+    <Compile Include="ModuleInitializers\ModuleInitializerAttribute.cs" />
     <Compile Include="WpfWindowStarter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/ModuleInitializers/LibraryModuleInitializer.cs
+++ b/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/ModuleInitializers/LibraryModuleInitializer.cs
@@ -1,0 +1,35 @@
+﻿//
+// Copyright (c) 2025 David Rettenbacher
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace AnotherClassLibrary.ModuleInitializers
+{
+    public static class LibraryModuleInitializer
+    {
+        [ModuleInitializer]
+        public static void Initialize()
+        {
+            // some "complex" code to prove the ModuleInitializersRepackStep can handle it
+            var shouldInitialize = DateTime.Now > new DateTime(2000, 1, 1);
+            if (shouldInitialize)
+            {
+                MakeInitialized.Initialize();
+            }
+        }
+    }
+}

--- a/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/ModuleInitializers/MakeInitialized.cs
+++ b/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/ModuleInitializers/MakeInitialized.cs
@@ -1,0 +1,35 @@
+﻿//
+// Copyright (c) 2025 David Rettenbacher
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+namespace AnotherClassLibrary.ModuleInitializers
+{
+    public class MakeInitialized
+    {
+        public static bool IsInitialized { get; private set; }
+
+        public static int Counter { get;private set; }
+
+        public static void Initialize()
+        {
+            IsInitialized = true;
+
+            Counter = ClassLibrary.ModuleInitializers.MakeInitialized.Counter + 1;
+
+            // force an actual assembly dependency to ClassLibrary
+            ClassLibrary.DummyConverter dummy = new ClassLibrary.DummyConverter();
+        }
+    }
+}

--- a/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/ModuleInitializers/ModuleInitializerAttribute.cs
+++ b/ILRepack.IntegrationTests/Scenarios/AnotherClassLibrary/ModuleInitializers/ModuleInitializerAttribute.cs
@@ -1,0 +1,33 @@
+﻿//
+// Copyright (c) 2025 David Rettenbacher
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace System.Runtime.CompilerServices
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+{
+    /// <summary>
+    /// Polyfill for compiler support
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [DebuggerNonUserCode]
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class ModuleInitializerAttribute : Attribute
+    {
+    }
+}

--- a/ILRepack.IntegrationTests/Scenarios/ClassLibrary/ClassLibrary.csproj
+++ b/ILRepack.IntegrationTests/Scenarios/ClassLibrary/ClassLibrary.csproj
@@ -42,6 +42,9 @@
       <DependentUpon>DummyUserControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="GenericBasedResourceKey.cs" />
+    <Compile Include="ModuleInitializers\LibraryModuleInitializer.cs" />
+    <Compile Include="ModuleInitializers\MakeInitialized.cs" />
+    <Compile Include="ModuleInitializers\ModuleInitializerAttribute.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/ILRepack.IntegrationTests/Scenarios/ClassLibrary/ModuleInitializers/LibraryModuleInitializer.cs
+++ b/ILRepack.IntegrationTests/Scenarios/ClassLibrary/ModuleInitializers/LibraryModuleInitializer.cs
@@ -1,0 +1,29 @@
+﻿//
+// Copyright (c) 2025 David Rettenbacher
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Runtime.CompilerServices;
+
+namespace ClassLibrary.ModuleInitializers
+{
+    public static class LibraryModuleInitializer
+    {
+        [ModuleInitializer]
+        public static void Initialize()
+        {
+            MakeInitialized.Initialize();
+        }
+    }
+}

--- a/ILRepack.IntegrationTests/Scenarios/ClassLibrary/ModuleInitializers/MakeInitialized.cs
+++ b/ILRepack.IntegrationTests/Scenarios/ClassLibrary/ModuleInitializers/MakeInitialized.cs
@@ -1,0 +1,32 @@
+﻿//
+// Copyright (c) 2025 David Rettenbacher
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+namespace ClassLibrary.ModuleInitializers
+{
+    public class MakeInitialized
+    {
+        public static bool IsInitialized { get; private set; }
+
+        public static int Counter { get; private set; }
+
+        public static void Initialize()
+        {
+            Counter++;
+
+            IsInitialized = true;
+        }
+    }
+}

--- a/ILRepack.IntegrationTests/Scenarios/ClassLibrary/ModuleInitializers/ModuleInitializerAttribute.cs
+++ b/ILRepack.IntegrationTests/Scenarios/ClassLibrary/ModuleInitializers/ModuleInitializerAttribute.cs
@@ -1,0 +1,33 @@
+﻿//
+// Copyright (c) 2025 David Rettenbacher
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace System.Runtime.CompilerServices
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+{
+    /// <summary>
+    /// Polyfill for compiler support
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [DebuggerNonUserCode]
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class ModuleInitializerAttribute : Attribute
+    {
+    }
+}

--- a/ILRepack.IntegrationTests/Scenarios/NestedLibraryUsageInXAML/MainWindow.xaml.cs
+++ b/ILRepack.IntegrationTests/Scenarios/NestedLibraryUsageInXAML/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using AnotherClassLibrary;
 
 namespace NestedLibraryUsageInXAML
@@ -13,6 +14,18 @@ namespace NestedLibraryUsageInXAML
         private async void MainWindowLoaded(object sender, RoutedEventArgs e)
         {
             await new BclAsyncUsage().GetNumber();
+
+            if (!ClassLibrary.ModuleInitializers.MakeInitialized.IsInitialized &&
+                ClassLibrary.ModuleInitializers.MakeInitialized.Counter == 1)
+                throw new InvalidOperationException($"ModuleInitializer of '{nameof(ClassLibrary.ModuleInitializers.LibraryModuleInitializer)}' was not executed");
+
+            if (!AnotherClassLibrary.ModuleInitializers.MakeInitialized.IsInitialized &&
+                AnotherClassLibrary.ModuleInitializers.MakeInitialized.Counter == 2)
+                throw new InvalidOperationException($"ModuleInitializer of '{nameof(AnotherClassLibrary.ModuleInitializers.LibraryModuleInitializer)}' was not executed or not in right order");
+
+            if (Program.Counter != 3)
+                throw new InvalidOperationException($"ModuleInitializers of '{nameof(Program)}' were not executed or not in right order");
+
             Close();
         }
     }

--- a/ILRepack.IntegrationTests/Scenarios/NestedLibraryUsageInXAML/ModuleInitializers/ModuleInitializerAttribute.cs
+++ b/ILRepack.IntegrationTests/Scenarios/NestedLibraryUsageInXAML/ModuleInitializers/ModuleInitializerAttribute.cs
@@ -1,0 +1,33 @@
+﻿//
+// Copyright (c) 2025 David Rettenbacher
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace System.Runtime.CompilerServices
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+{
+    /// <summary>
+    /// Polyfill for compiler support
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    [DebuggerNonUserCode]
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class ModuleInitializerAttribute : Attribute
+    {
+    }
+}

--- a/ILRepack.IntegrationTests/Scenarios/NestedLibraryUsageInXAML/Program.cs
+++ b/ILRepack.IntegrationTests/Scenarios/NestedLibraryUsageInXAML/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Windows;
 
 namespace NestedLibraryUsageInXAML
@@ -18,6 +19,21 @@ namespace NestedLibraryUsageInXAML
                 Console.WriteLine(e);
                 return 1;
             }
+        }
+
+        internal static int Counter { get; private set; }
+
+        [ModuleInitializer]
+        internal static void TheInitializer()
+        {
+            Counter++;
+            Counter *= AnotherClassLibrary.ModuleInitializers.MakeInitialized.Counter;
+        }
+
+        [ModuleInitializer]
+        internal static void TheInitializer2()
+        {
+            Counter++;
         }
     }
 }

--- a/ILRepack.IntegrationTests/Scenarios/NestedLibraryUsageInXAML/Properties/launchSettings.json
+++ b/ILRepack.IntegrationTests/Scenarios/NestedLibraryUsageInXAML/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "NestedLibraryUsageInXAML": {
+      "commandName": "Project"
+    },
+    "Merged": {
+      "commandName": "Executable",
+      "executablePath": "$(TargetDir)merged\\NestedLibraryUsageInXAML.exe"
+    }
+  }
+}

--- a/ILRepack/ILRepack.cs
+++ b/ILRepack/ILRepack.cs
@@ -419,6 +419,7 @@ namespace ILRepacking
                 {
                     signingStep,
                     new ReferencesRepackStep(Logger, this, Options),
+                    new ModuleInitializersRepackStep(Logger, this, Options),
                     new TypesRepackStep(Logger, this, _repackImporter, Options),
                     new ILLinkFileMergeStep(Logger, this, Options),
                     new ResourcesRepackStep(Logger, this, Options),

--- a/ILRepack/Steps/ModuleInitializersRepackStep.cs
+++ b/ILRepack/Steps/ModuleInitializersRepackStep.cs
@@ -119,7 +119,8 @@ namespace ILRepacking.Steps
 
         private void DemoteModuleInitializerMethodToNormalMethod(MethodDefinition initializer)
         {
-            var newName = $"{initializer.Module.Assembly.Name.ToString().Replace(" ", "_").Replace("=", "_").Replace(",", "")}_ModuleInitializer";
+            var newName = $"{initializer.Module.Assembly.Name}_{Path.GetFileNameWithoutExtension(initializer.Module.Name)}_ModuleInitializer";
+            newName = newName.Replace(" ", "_").Replace("=", "_").Replace(",", "").Replace(".", "_");
 
             _logger.Verbose($"  - Rename module initializer of '{initializer.Module.Assembly.Name.Name}' to '{newName}'");
 

--- a/ILRepack/Steps/ModuleInitializersRepackStep.cs
+++ b/ILRepack/Steps/ModuleInitializersRepackStep.cs
@@ -119,7 +119,7 @@ namespace ILRepacking.Steps
 
         private void DemoteModuleInitializerMethodToNormalMethod(MethodDefinition initializer)
         {
-            var newName = $"{initializer.Module.Assembly.Name.Name}_.ModuleInitializer";
+            var newName = $"{initializer.Module.Assembly.Name.ToString().Replace(" ", "_").Replace("=", "_").Replace(",", "")}_ModuleInitializer";
 
             _logger.Verbose($"  - Rename module initializer of '{initializer.Module.Assembly.Name.Name}' to '{newName}'");
 

--- a/ILRepack/Steps/ModuleInitializersRepackStep.cs
+++ b/ILRepack/Steps/ModuleInitializersRepackStep.cs
@@ -1,0 +1,138 @@
+﻿//
+// Copyright (c) 2025 David Rettenbacher
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILRepacking.Steps
+{
+    internal class ModuleInitializersRepackStep : IRepackStep
+    {
+        private readonly ILogger _logger;
+        private readonly IRepackContext _repackContext;
+
+        public ModuleInitializersRepackStep(
+            ILogger logger,
+            IRepackContext repackContext,
+            RepackOptions repackOptions)
+        {
+            _logger = logger;
+            _repackContext = repackContext;
+        }
+
+        public void Perform()
+        {
+            RepackModuleInitializers();
+        }
+
+        private void RepackModuleInitializers()
+        {
+            _logger.Verbose("Processing module initializers");
+
+            var otherModules = _repackContext.OtherAssemblies.SelectMany(x => x.Modules).ToArray();
+            MergeModuleInitializers(_repackContext.TargetAssemblyMainModule, otherModules);
+        }
+
+        /// <summary>
+        /// Checks if there are other module initializers to call from the primary module initializer.
+        /// If that is the case the module initializer gets renamed, a new initializer is added, calls all other module initializers
+        /// and at the end the original initializer. The other initializers are then re
+        /// </summary>
+        /// <param name="mainAssembly">Die Assembly, in der der kombinierte Module-Initializer angelegt wird.</param>
+        /// <param name="assemblies">Die Assemblys, aus denen die Module-Initializer eingesammelt werden.</param>
+        private void MergeModuleInitializers(ModuleDefinition mainModule, IEnumerable<ModuleDefinition> modulesToMerge)
+        {
+            var anyModuleInitializersToMerge = modulesToMerge.Any(m => m.Types.Any(t => t.Name == "<Module>"));
+            if (!anyModuleInitializersToMerge)
+            {
+                _logger.Verbose("- Found no module initializers to be merged - skip");
+                return;
+            }
+
+            var mainModuleType = mainModule.Types.FirstOrDefault(t => t.Name == "<Module>");
+            if (mainModuleType is null)
+            {
+                mainModuleType = new TypeDefinition(
+                    "",
+                    "<Module>",
+                    TypeAttributes.NotPublic | TypeAttributes.AutoClass | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit,
+                    mainModule.TypeSystem.Object
+                );
+                mainModule.Types.Add(mainModuleType);
+            }
+
+            var originalMainInitializer = mainModuleType.Methods.FirstOrDefault(m => m.Name == ".cctor");
+            if (originalMainInitializer is not null)
+            {
+                _logger.Verbose($"- Process main module initializer");
+
+                DemoteModuleInitializerMethodToNormalMethod(originalMainInitializer);
+            }
+
+            var newMainInitializer = new MethodDefinition(
+                ".cctor",
+                MethodAttributes.Private | MethodAttributes.Static | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
+                mainModule.TypeSystem.Void
+            );
+
+            var newIl = newMainInitializer.Body.GetILProcessor();
+
+            foreach (var moduleToMerge in modulesToMerge)
+            {
+                // search inside the assembly the module initializer type "<Module>"
+                var type = moduleToMerge.Types.FirstOrDefault(t => t.Name == "<Module>");
+                if (type is null)
+                    continue;
+
+                // search its static constructor (the module initializer method)
+                var subInitializer = type.Methods.FirstOrDefault(m => m.Name == ".cctor" && m.IsStatic);
+                if (subInitializer is null)
+                    continue;
+
+                _logger.Verbose($"- Process module initializer of '{moduleToMerge.Assembly.Name.Name}'");
+
+                DemoteModuleInitializerMethodToNormalMethod(subInitializer);
+
+                var call = newIl.Create(OpCodes.Call, mainModule.ImportReference(subInitializer));
+                newIl.Append(call);
+            }
+
+            if (originalMainInitializer is not null)
+            {
+                _logger.Verbose($"- Process original primary module initializer of {mainModule.Assembly.Name.Name}");
+                var callOriginal = newIl.Create(OpCodes.Call, originalMainInitializer);
+                newIl.Append(callOriginal);
+            }
+
+            newIl.Append(newIl.Create(OpCodes.Ret));
+
+            mainModuleType.Methods.Add(newMainInitializer);
+        }
+
+        private void DemoteModuleInitializerMethodToNormalMethod(MethodDefinition initializer)
+        {
+            var newName = $"{initializer.Module.Assembly.Name.Name}_ModuleInitializer";
+
+            _logger.Verbose($"  - Rename module initializer of '{initializer.Module.Assembly.Name.Name}' to '{newName}'");
+
+            initializer.Name = newName;
+            initializer.IsSpecialName = false;
+            initializer.IsRuntimeSpecialName = false;
+        }
+    }
+}

--- a/ILRepack/Steps/ModuleInitializersRepackStep.cs
+++ b/ILRepack/Steps/ModuleInitializersRepackStep.cs
@@ -53,11 +53,11 @@ namespace ILRepacking.Steps
 
         /// <summary>
         /// Checks if there are other module initializers to call from the primary module initializer.
-        /// If that is the case the module initializer gets renamed, a new initializer is added, calls all other module initializers
-        /// and at the end the original initializer. The other initializers are then re
+        /// If that is the case, a new initializer is added which calls all found module initializers.
+        /// All found initializers are renamed to be unique while still conveying their origin.
         /// </summary>
-        /// <param name="mainAssembly">Die Assembly, in der der kombinierte Module-Initializer angelegt wird.</param>
-        /// <param name="assemblies">Die Assemblys, aus denen die Module-Initializer eingesammelt werden.</param>
+        /// <param name="targetModule">Target module which gets the new module initializer</param>
+        /// <param name="modulesToMerge">Modules which should be scanned for module initializers.</param>
         private void MergeModuleInitializers(ModuleDefinition targetModule, IEnumerable<ModuleDefinition> modulesToMerge)
         {
             var anyModuleInitializersToMerge = modulesToMerge.Any(m =>


### PR DESCRIPTION
Adds support for preserving all module initializers. Without this, only one of the module initializers appears in the merged assembly because of deduplication.

- Adds separate step to handle module initializers
- Renames module initializer methods to unique name (prefixed with fully qualified assembly name)
- Generates new `<Module>` class where its static constructor calls all module initializers found in merged assemblies

Fixes #312.

Example of merged module initializers (decompiled by ILSpy):
```csharp
internal class <Module>
{
	static <Module>()
	{
		AnotherClassLibrary_Version_1.0.2.0_Culture_neutral_PublicKeyToken_null_ModuleInitializer();
		ClassLibrary_Version_1.0.2.0_Culture_neutral_PublicKeyToken_null_ModuleInitializer();
		WPFThemingAndLibraryStyles_Version_1.0.2.0_Culture_neutral_PublicKeyToken_null_ModuleInitializer();
	}

	private static void WPFThemingAndLibraryStyles_Version_1.0.2.0_Culture_neutral_PublicKeyToken_null_ModuleInitializer()
	{
		Program.InitializerOne();
		Program.InitializerTwo();
	}

	private static void AnotherClassLibrary_Version_1.0.2.0_Culture_neutral_PublicKeyToken_null_ModuleInitializer()
	{
		OtherModuleInitializer.Initialize();
	}

	private static void ClassLibrary_Version_1.0.2.0_Culture_neutral_PublicKeyToken_null_ModuleInitializer()
	{
		ModuleInitializer.Initialize();
	}
}


```

### Notes
- In general, once compiled, all methods of an assembly annotated with `[ModuleInitializer]` are merged into a namespace-less class named `<Module>`. Its static constructor calls all methods annotated with `[ModuleInitializer]` of its module. Therefore, only one type/method must be considered per module when ILRepack merges assemblies.

### Tests
Currently, I tested this feature by temporary adding some module initializers to existing projects and verify them with ILSpy/by running the applications. So, as of now, **those changes is not part of the PR!**

So the question is:
Should there be an additional set of integration scenario projects added to explicitly test merging modules, or should some existing projects be adapted to also test for module initializers being merged and working?v