### PR TITLE
Add `FieldType.FullName` in CloneTo and Fix methods for `Field`

### DIFF
--- a/ILRepack/ReferenceFixator.cs
+++ b/ILRepack/ReferenceFixator.cs
@@ -14,7 +14,6 @@
 //   limitations under the License.
 //
 
-using ILRepacking.Mixins;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Collections.Generic;

--- a/ILRepack/ReferenceFixator.cs
+++ b/ILRepack/ReferenceFixator.cs
@@ -549,7 +549,7 @@ namespace ILRepacking
                                      ? method.ReturnType
                                      : method.Parameters.First(x => x.ParameterType.IsDefinition).ParameterType;
                 // warn about invalid merge assembly set, as this method is not gonna work fine (peverify would warn as well)
-                string text =
+                string text = 
 @$"Method reference is used with definition return type / parameter.
 Indicates a likely invalid set of assemblies, consider one of the following:
  - Remove the assembly defining {culprit} from the merge

--- a/ILRepack/ReferenceFixator.cs
+++ b/ILRepack/ReferenceFixator.cs
@@ -73,7 +73,7 @@ namespace ILRepacking
             {
                 FieldDefinition def = ((TypeDefinition)field.DeclaringType).Fields.FirstOrDefault(x => x.Name == field.Name && x.FieldType.FullName == field.FieldType.FullName);
                 if (def == null)
-                    throw new NullReferenceException("Field \"" + field + "\" not found in type \"" + field.DeclaringType + "\".");
+                    throw new NullReferenceException("Field \"" + field + "\" with field type \"" + field.FieldType + "\" not found in type \"" + field.DeclaringType + "\".");
                 return def;
             }
             field.FieldType = Fix(field.FieldType);

--- a/ILRepack/ReferenceFixator.cs
+++ b/ILRepack/ReferenceFixator.cs
@@ -14,6 +14,7 @@
 //   limitations under the License.
 //
 
+using ILRepacking.Mixins;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Collections.Generic;
@@ -71,7 +72,10 @@ namespace ILRepacking
             field.DeclaringType = Fix(field.DeclaringType);
             if (field.DeclaringType.IsDefinition && !field.IsDefinition)
             {
-                FieldDefinition def = ((TypeDefinition)field.DeclaringType).Fields.FirstOrDefault(x => x.Name == field.Name && x.FieldType.FullName == field.FieldType.FullName);
+                var matches = ((TypeDefinition)field.DeclaringType).Fields.Where(f => f.Name == field.Name).ToList();
+                FieldDefinition def = matches.Count > 1 ?
+                                      matches.FirstOrDefault(f => f.FieldType.FullName == field.FieldType.FullName) :
+                                      matches.FirstOrDefault();
                 if (def == null)
                     throw new NullReferenceException("Field \"" + field + "\" with field type \"" + field.FieldType + "\" not found in type \"" + field.DeclaringType + "\".");
                 return def;
@@ -546,7 +550,7 @@ namespace ILRepacking
                                      ? method.ReturnType
                                      : method.Parameters.First(x => x.ParameterType.IsDefinition).ParameterType;
                 // warn about invalid merge assembly set, as this method is not gonna work fine (peverify would warn as well)
-                string text = 
+                string text =
 @$"Method reference is used with definition return type / parameter.
 Indicates a likely invalid set of assemblies, consider one of the following:
  - Remove the assembly defining {culprit} from the merge

--- a/ILRepack/ReferenceFixator.cs
+++ b/ILRepack/ReferenceFixator.cs
@@ -71,7 +71,7 @@ namespace ILRepacking
             field.DeclaringType = Fix(field.DeclaringType);
             if (field.DeclaringType.IsDefinition && !field.IsDefinition)
             {
-                FieldDefinition def = ((TypeDefinition)field.DeclaringType).Fields.FirstOrDefault(x => x.Name == field.Name);
+                FieldDefinition def = ((TypeDefinition)field.DeclaringType).Fields.FirstOrDefault(x => x.Name == field.Name && x.FieldType.FullName == field.FieldType.FullName);
                 if (def == null)
                     throw new NullReferenceException("Field \"" + field + "\" not found in type \"" + field.DeclaringType + "\".");
                 return def;

--- a/ILRepack/RepackImporter.cs
+++ b/ILRepack/RepackImporter.cs
@@ -318,7 +318,7 @@ namespace ILRepacking
         /// </summary>
         private void CloneTo(FieldDefinition field, TypeDefinition nt)
         {
-            if (nt.Fields.Any(x => x.Name == field.Name))
+            if (nt.Fields.Any(x => x.Name == field.Name && x.FieldType.FullName == field.FieldType.FullName))
             {
                 return;
             }


### PR DESCRIPTION
There are some possibility to have two fields with same `Name` and different type.

This PR updates: 
* The `CloneTo` method for field to check `Name` and `FieldType.FullName` already exists.
* The `Fix` method for field to find the field using `Name` and `FieldType.FullName`.

Before only the `Name` was used. 

Related to issue: #423